### PR TITLE
AB#54591 - reduce sumologic consumption

### DIFF
--- a/loggroup-lambda-connector/sam/cleanup_unmatched_filters.sh
+++ b/loggroup-lambda-connector/sam/cleanup_unmatched_filters.sh
@@ -20,7 +20,13 @@ set -euo pipefail
 
 AWS_REGION="us-west-2"
 FILTER_NAME="SumoLGLBDFilter"
-PARALLEL=20
+# CloudWatch Logs rate-limits state-changing calls to ~5 TPS. Keep parallelism
+# low to avoid throttling; AWS CLI v2 adaptive retries handle occasional 429s.
+PARALLEL=5
+
+# Aggressive retry on throttling for every aws CLI call made by this script.
+export AWS_RETRY_MODE=adaptive
+export AWS_MAX_ATTEMPTS=10
 
 # Keep in sync with LOG_GROUP_PATTERN in sam_package.sh. Written as a POSIX ERE
 # (no negative lookahead needed — this is a pure allowlist).
@@ -56,38 +62,68 @@ echo
 check_one() {
   local lg="$1"
 
-  local has_filter
-  has_filter=$(aws logs describe-subscription-filters \
+  # Distinguish real "no filter" from API errors. The earlier version swallowed
+  # both into empty-string, so throttled describes looked like "no filter" and
+  # log groups were silently skipped.
+  local describe_out
+  local describe_rc
+  describe_out=$(aws logs describe-subscription-filters \
     --log-group-name "$lg" \
     --filter-name-prefix "$FILTER_NAME" \
     --region "$AWS_REGION" \
     --query 'subscriptionFilters[].filterName' \
-    --output text 2>/dev/null || echo "")
+    --output text 2>&1)
+  describe_rc=$?
 
-  if [[ -z "$has_filter" ]]; then
-    # Common case; emit a progress tick to stderr so stdout stays clean.
+  if [[ $describe_rc -ne 0 ]]; then
+    echo "ERROR-DESCRIBE $lg -- $describe_out" >&2
+    return 1
+  fi
+
+  if [[ -z "$describe_out" ]]; then
+    # Log group genuinely has no filter; progress tick only.
     echo -n "." >&2
     return 0
   fi
 
   if echo "$lg" | grep -Eq "$ALLOWLIST_REGEX"; then
     echo "KEEP         $lg"
-  elif [[ "$EXECUTE" == "true" ]]; then
-    aws logs delete-subscription-filter \
-      --log-group-name "$lg" \
-      --filter-name "$FILTER_NAME" \
-      --region "$AWS_REGION"
+    return 0
+  fi
+
+  if [[ "$EXECUTE" != "true" ]]; then
+    echo "WOULD-DELETE $lg"
+    return 0
+  fi
+
+  # Actually delete, verifying the call succeeded. Fall back to reporting a
+  # failure line (on stderr) so it's obvious which log groups still need
+  # attention after the run.
+  local delete_out
+  local delete_rc
+  delete_out=$(aws logs delete-subscription-filter \
+    --log-group-name "$lg" \
+    --filter-name "$FILTER_NAME" \
+    --region "$AWS_REGION" 2>&1)
+  delete_rc=$?
+
+  if [[ $delete_rc -eq 0 ]]; then
     echo "DELETED      $lg"
   else
-    echo "WOULD-DELETE $lg"
+    echo "FAILED       $lg -- $delete_out" >&2
+    return 1
   fi
 }
 
 export -f check_one
 export AWS_REGION FILTER_NAME ALLOWLIST_REGEX EXECUTE
+# AWS_RETRY_MODE and AWS_MAX_ATTEMPTS are already exported above.
 
 echo "$LOG_GROUPS" | xargs -I{} -P "$PARALLEL" bash -c 'check_one "$@"' _ {}
 
 echo
 echo
 echo ">>> Done. (Each dot on stderr = one log group without our filter.)"
+echo ">>> If you saw ERROR-DESCRIBE or FAILED lines on stderr, re-run — those"
+echo ">>> log groups were NOT processed. Redirect stderr to a file to capture:"
+echo ">>>     ./cleanup_unmatched_filters.sh --execute 2>cleanup.errors"

--- a/loggroup-lambda-connector/sam/cleanup_unmatched_filters.sh
+++ b/loggroup-lambda-connector/sam/cleanup_unmatched_filters.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+#
+# Delete the SumoLGLBDFilter subscription filter from any CloudWatch log group
+# that no longer matches the current LogGroupPattern in sam_package.sh.
+#
+# The SumoLogGroupLambdaConnector only *creates* subscription filters; it has
+# no unsubscribe logic. When the allowlist regex tightens, previously-matching
+# log groups keep their filters and keep forwarding to SumoLogic until the
+# filter is deleted explicitly. This script does that cleanup.
+#
+# Dry-run by default. Pass --execute to actually delete.
+#
+# Usage:
+#   ./cleanup_unmatched_filters.sh              # dry-run
+#   ./cleanup_unmatched_filters.sh --execute    # actually delete unmatched filters
+#
+# Requirements: awscli v2, xargs (-P). Works on macOS's bash 3.2.
+
+set -euo pipefail
+
+AWS_REGION="us-west-2"
+FILTER_NAME="SumoLGLBDFilter"
+PARALLEL=20
+
+# Keep in sync with LOG_GROUP_PATTERN in sam_package.sh. Written as a POSIX ERE
+# (no negative lookahead needed — this is a pure allowlist).
+ALLOWLIST_REGEX='^/aws/(lambda|fargate)/(admin-|alert-generator[-_]|clearwater-|diag-|el_matador-|hermosa-production|hss-etl-|kafka-punches-to-kronos-publisher-production|kafka-to-kronos-exporter|lido-(consumer|api|jobs)-|scheduler-|tabletop[-_]|vendor-|windansea-)'
+
+EXECUTE=false
+if [[ "${1:-}" == "--execute" ]]; then
+  EXECUTE=true
+fi
+
+if $EXECUTE; then
+  echo ">>> EXECUTE mode: will DELETE filters from unmatched log groups"
+else
+  echo ">>> DRY-RUN mode: pass --execute to actually delete"
+fi
+echo ">>> Region: $AWS_REGION"
+echo ">>> Filter: $FILTER_NAME"
+echo ">>> Parallelism: $PARALLEL"
+echo
+
+echo ">>> Fetching all log groups..."
+LOG_GROUPS=$(
+  aws logs describe-log-groups \
+    --region "$AWS_REGION" \
+    --output text \
+    --query 'logGroups[].logGroupName' | tr '\t' '\n' | sed '/^$/d'
+)
+TOTAL=$(echo "$LOG_GROUPS" | wc -l | tr -d ' ')
+echo ">>> Found $TOTAL log groups. Checking each for the $FILTER_NAME filter..."
+echo ">>> (Log groups without our filter are skipped silently — KEEP/DELETE lines only)"
+echo
+
+check_one() {
+  local lg="$1"
+
+  local has_filter
+  has_filter=$(aws logs describe-subscription-filters \
+    --log-group-name "$lg" \
+    --filter-name-prefix "$FILTER_NAME" \
+    --region "$AWS_REGION" \
+    --query 'subscriptionFilters[].filterName' \
+    --output text 2>/dev/null || echo "")
+
+  if [[ -z "$has_filter" ]]; then
+    # Common case; emit a progress tick to stderr so stdout stays clean.
+    echo -n "." >&2
+    return 0
+  fi
+
+  if echo "$lg" | grep -Eq "$ALLOWLIST_REGEX"; then
+    echo "KEEP         $lg"
+  elif [[ "$EXECUTE" == "true" ]]; then
+    aws logs delete-subscription-filter \
+      --log-group-name "$lg" \
+      --filter-name "$FILTER_NAME" \
+      --region "$AWS_REGION"
+    echo "DELETED      $lg"
+  else
+    echo "WOULD-DELETE $lg"
+  fi
+}
+
+export -f check_one
+export AWS_REGION FILTER_NAME ALLOWLIST_REGEX EXECUTE
+
+echo "$LOG_GROUPS" | xargs -I{} -P "$PARALLEL" bash -c 'check_one "$@"' _ {}
+
+echo
+echo
+echo ">>> Done. (Each dot on stderr = one log group without our filter.)"

--- a/loggroup-lambda-connector/sam/sam_package.sh
+++ b/loggroup-lambda-connector/sam/sam_package.sh
@@ -2,7 +2,7 @@
 
 SAM_S3_BUCKET="kbs-sumologic-connector"
 AWS_REGION="us-west-2"
-LOG_GROUP_PATTERN="\/aws\/(lambda|fargate)\/(?!(kanaha|rdb|wasaga|.+?_producer_|workday\-producers)).+"
+LOG_GROUP_PATTERN="\/aws\/(lambda|fargate)\/(admin\-|alert\-generator[\-_]|clearwater\-|diag\-|el_matador\-|hermosa\-production|hss\-etl\-|kafka\-punches\-to\-kronos\-publisher\-production|kafka\-to\-kronos\-exporter|lido\-(consumer|api|jobs)\-|scheduler\-|tabletop[\-_]|vendor\-|windansea\-).+"
 
 version="1.0.4"
 


### PR DESCRIPTION
AB#54591 - reduce sumologic consumption

`cleanup_unmatched_filters.sh` - this new script compares all of the existing Log filters to see i they match the new regex or not.  if they do not, it removes them.

<details>
<summary>dry run output: </summary>

```
>>> DRY-RUN mode: pass --execute to actually delete
>>> Region: us-west-2
>>> Filter: SumoLGLBDFilter
>>> Parallelism: 20

>>> Fetching all log groups...
>>> Found 3606 log groups. Checking each for the SumoLGLBDFilter filter...
>>> (Log groups without our filter are skipped silently — KEEP/DELETE lines only)

KEEP         /aws/fargate/admin-new-staging-smoke
KEEP         /aws/fargate/admin-new-staging-web
KEEP         /aws/fargate/admin-staging-web
KEEP         /aws/fargate/admin-production-web
KEEP         /aws/fargate/alert-generator-production-clearer-v2
KEEP         /aws/fargate/alert-generator-production-clearer
KEEP         /aws/fargate/alert-generator-production-generator-v2
KEEP         /aws/fargate/alert-generator-staging-clearer-v2
KEEP         /aws/fargate/alert-generator-staging-exception_thrower
KEEP         /aws/fargate/alert-generator-production-generator
KEEP         /aws/fargate/alert-generator-staging-generator-v2
KEEP         /aws/fargate/alert-generator-staging-generator
KEEP         /aws/fargate/alert-generator_staging
WOULD-DELETE /aws/fargate/avalon-production-etl
WOULD-DELETE /aws/fargate/avalon-demo-etl
WOULD-DELETE /aws/fargate/avalon-staging-etl
KEEP         /aws/fargate/alert-generator-staging-clearer
KEEP         /aws/fargate/clearwater-production-accurate_command_processor
KEEP         /aws/fargate/clearwater-production-accurate_background_check_refresher
WOULD-DELETE /aws/fargate/avalon-beta-etl
KEEP         /aws/fargate/clearwater-production-accurate_manual_background_check_fetcher-v2
KEEP         /aws/fargate/clearwater-production-background_check_code_external_code_setter
KEEP         /aws/fargate/alert-generator-staging-error_reporter
KEEP         /aws/fargate/clearwater-production-clearwater_command_processor
KEEP         /aws/fargate/clearwater-production-clearwater_conf_consumer
KEEP         /aws/fargate/clearwater-production-confirmations_api-v2
KEEP         /aws/fargate/clearwater-production-email_command_processor-v2
KEEP         /aws/fargate/clearwater-production-clearwater_command_processor-v2
KEEP         /aws/fargate/clearwater-production-fadv_background_check_refresher
KEEP         /aws/fargate/alert-generator_production
KEEP         /aws/fargate/clearwater-production-email_command_processor
KEEP         /aws/fargate/clearwater-production-completed_background_check_exporter-v2
KEEP         /aws/fargate/clearwater-production-gsn_background_check_refresher-v2
KEEP         /aws/fargate/clearwater-production-gsn_command_processor
KEEP         /aws/fargate/clearwater-production-open4_conf_consumer
KEEP         /aws/fargate/clearwater-production-conf_num_allocating_consumer
KEEP         /aws/fargate/clearwater-production-sterling_command_processor
KEEP         /aws/fargate/clearwater-staging-accurate_background_check_refresher
KEEP         /aws/fargate/clearwater-production-sterling_drug_test_reorderer-v2
KEEP         /aws/fargate/clearwater-staging-accurate_manual_background_check_fetcher
KEEP         /aws/fargate/clearwater-staging-confirmations_api
KEEP         /aws/fargate/clearwater-staging-sterling_incomplete_drug_test_checker-v2
KEEP         /aws/fargate/clearwater-staging-open4_command_processor
WOULD-DELETE /aws/fargate/crewlocate-production-web
KEEP         /aws/fargate/clearwater-staging-sterling_command_processor
KEEP         /aws/fargate/diag-production-migrate_and_seed
KEEP         /aws/fargate/diag-staging-migrate_and_seed
KEEP         /aws/fargate/clearwater-staging-sterling_incomplete_background_check_checker
KEEP         /aws/fargate/diag-production-web
KEEP         /aws/fargate/clearwater-staging-gsn_drug_test_command_processor-v2
KEEP         /aws/fargate/clearwater-staging-sterling_drug_test_reorderer
KEEP         /aws/fargate/clearwater-staging-sterling_incomplete_drug_test_checker
KEEP         /aws/fargate/clearwater-staging-sterling_drug_test_reorderer-v2
KEEP         /aws/fargate/diag-staging-web
WOULD-DELETE /aws/fargate/ecs_tester-staging-print_every_minute
KEEP         /aws/fargate/clearwater-staging-sterling_incomplete_candidate_info_background_check_checker
KEEP         /aws/fargate/el_matador-production-migrate_and_seed
KEEP         /aws/fargate/el_matador-staging-migrate_and_seed
KEEP         /aws/fargate/clearwater-staging-pe_command_processor
KEEP         /aws/fargate/el_matador-production-web
WOULD-DELETE /aws/fargate/epay-punch-producer_staging
WOULD-DELETE /aws/fargate/execution_monitor_production
KEEP         /aws/fargate/clearwater-staging-sterling_command_processor-v2
WOULD-DELETE /aws/fargate/flatrock-beta-punch_watcher
KEEP         /aws/fargate/clearwater-staging-open4_conf_consumer
WOULD-DELETE /aws/fargate/flatrock-beta-web
WOULD-DELETE /aws/fargate/epay-punch-producer_production
WOULD-DELETE /aws/fargate/flatrock-beta-delayed_jobs_runner
WOULD-DELETE /aws/fargate/flatrock-production-web
WOULD-DELETE /aws/fargate/flatrock-staging-punch_watcher
KEEP         /aws/fargate/el_matador-staging-web
WOULD-DELETE /aws/fargate/hermosa-staging-migrate_and_seed
KEEP         /aws/fargate/hss-etl-production-assignment_loader
WOULD-DELETE /aws/fargate/flatrock-staging-delayed_jobs_runner
WOULD-DELETE /aws/fargate/flatrock-demo-web
KEEP         /aws/fargate/clearwater-staging-pe_incomplete_background_check_checker
KEEP         /aws/fargate/hss-etl-production-public_ip_check
WOULD-DELETE /aws/fargate/flatrock-demo-delayed_jobs_runner
KEEP         /aws/fargate/hss-etl-staging-assignment_loader-v2
WOULD-DELETE /aws/fargate/kafka-connect-mongo-staging-connector
WOULD-DELETE /aws/fargate/kafka-punches-to-kronos-publisher-staging-punch_import_row_counter-v2
KEEP         /aws/fargate/kafka-to-kronos-exporter_kbs_location_staging
KEEP         /aws/fargate/kafka-to-kronos-exporter_kbs_punch_staging
WOULD-DELETE /aws/fargate/kafka-to-kronos-publisher-legacy-kronos_kbs_location_staging
WOULD-DELETE /aws/fargate/kafka-to-kronos-publisher-legacy-kronos_kbs_punch_staging
WOULD-DELETE /aws/fargate/kbs-slack-bot-demo-bot
KEEP         /aws/fargate/kafka-to-kronos-exporter_vfs_location_staging
WOULD-DELETE /aws/fargate/kbs-slack-bot_staging
WOULD-DELETE /aws/fargate/kbs-teams-bot-production-api_server
WOULD-DELETE /aws/fargate/kbs-slack-bot_production
WOULD-DELETE /aws/fargate/kafka-to-kronos-publisher-legacy-kronos_kbs_location_production
WOULD-DELETE /aws/fargate/kbs-teams-bot-staging-api_server
WOULD-DELETE /aws/fargate/kbs_labor_details_producer_staging
WOULD-DELETE /aws/fargate/kbs_labor_details_producer_production
WOULD-DELETE /aws/fargate/kbs-slack-bot-staging-bot
WOULD-DELETE /aws/fargate/kbs-slack-bot-production-bot
WOULD-DELETE /aws/fargate/kbs-slack-bot_demo
WOULD-DELETE /aws/fargate/kbs-slack-bot-staging-kbs_slack_bot
WOULD-DELETE /aws/fargate/kbs-slack-bot-beta-bot
WOULD-DELETE /aws/fargate/laguna_asset_panda_location_exporter_production
WOULD-DELETE /aws/fargate/netsuite-etl-beta-DailyBudgetsETL
WOULD-DELETE /aws/fargate/netsuite-etl-beta-DrugTestingConfigurationsETL
WOULD-DELETE /aws/fargate/netsuite-etl-beta-LocationTypesETL
WOULD-DELETE /aws/fargate/netsuite-etl-beta-PosPreferencesETL
WOULD-DELETE /aws/fargate/netsuite-etl-beta-ChecksETL
WOULD-DELETE /aws/fargate/netsuite-etl-beta-LocationsETL
WOULD-DELETE /aws/fargate/netsuite-etl-beta-ServiceItemsETL
WOULD-DELETE /aws/fargate/netsuite-etl-beta-PosStatusesETL
WOULD-DELETE /aws/fargate/netsuite-etl-beta-ServiceOrderApStatusesETL
WOULD-DELETE /aws/fargate/netsuite-etl-beta-ServiceOrderStatusesETL
WOULD-DELETE /aws/fargate/netsuite-etl-beta-ServiceOrdersETL
WOULD-DELETE /aws/fargate/netsuite-etl-beta-SubPaymentHistoryETL
WOULD-DELETE /aws/fargate/netsuite-etl-beta-ServiceOrdersUpdatesETL
WOULD-DELETE /aws/fargate/netsuite-etl-beta-VendorsLocationsETL
WOULD-DELETE /aws/fargate/netsuite-etl-demo-LocationTypesETL
WOULD-DELETE /aws/fargate/netsuite-etl-demo-DrugTestingConfigurationsETL
WOULD-DELETE /aws/fargate/netsuite-etl-demo-LocationsETL
WOULD-DELETE /aws/fargate/netsuite-etl-demo-ServiceOrderApStatusesETL
WOULD-DELETE /aws/fargate/netsuite-etl-demo-ServiceItemsETL
WOULD-DELETE /aws/fargate/netsuite-etl-beta-VendorsETL
WOULD-DELETE /aws/fargate/kbs-slack-bot_beta
WOULD-DELETE /aws/fargate/netsuite-etl-demo-ServiceOrderStatusesETL
WOULD-DELETE /aws/fargate/netsuite-etl-demo-ServiceOrdersUpdatesETL
WOULD-DELETE /aws/fargate/netsuite-etl-demo-ServiceRecordsETL
WOULD-DELETE /aws/fargate/netsuite-etl-demo-SubPaymentHistoryETL
WOULD-DELETE /aws/fargate/netsuite-etl-demo-PosStatusesETL
WOULD-DELETE /aws/fargate/netsuite-etl-beta-ServiceRecordsETL
WOULD-DELETE /aws/fargate/netsuite-etl-production-PosStatusesETL
WOULD-DELETE /aws/fargate/netsuite-etl-production-ServiceItemsETL
WOULD-DELETE /aws/fargate/netsuite-etl-production-ChecksETL
WOULD-DELETE /aws/fargate/netsuite-etl-production-ServiceOrdersUpdatesETL
WOULD-DELETE /aws/fargate/netsuite-etl-production-ServiceRecordsETL
WOULD-DELETE /aws/fargate/netsuite-etl-production-VendorsETL
WOULD-DELETE /aws/fargate/netsuite-etl-production-ServiceOrderArStatusesETL
WOULD-DELETE /aws/fargate/netsuite-etl-production-SubPaymentHistoryETL
WOULD-DELETE /aws/fargate/netsuite-etl-demo-VendorsLocationsETL
WOULD-DELETE /aws/fargate/netsuite-etl-production-VendorsLocationsETL
WOULD-DELETE /aws/fargate/netsuite-etl_LocationsETL_staging
WOULD-DELETE /aws/fargate/netsuite-etl_ServiceRecordsETL_beta
WOULD-DELETE /aws/fargate/netsuite-etl_ServiceRecordsETL_demo
WOULD-DELETE /aws/fargate/netsuite-etl_DailyBudgetsETL_demo
WOULD-DELETE /aws/fargate/netsuite-etl_DailyBudgetsETL_staging
WOULD-DELETE /aws/fargate/netsuite-etl_ServiceOrdersUpdatesETL_beta
WOULD-DELETE /aws/fargate/netsuite-etl_LocationTypesETL_beta
WOULD-DELETE /aws/fargate/netsuite-etl_LocationTypesETL_staging
WOULD-DELETE /aws/fargate/netsuite-etl_ServiceRecordsETL_staging
WOULD-DELETE /aws/fargate/netsuite-etl_SubPaymentHistoryETL_demo
WOULD-DELETE /aws/fargate/netsuite-etl_SubPaymentHistoryETL_beta
WOULD-DELETE /aws/fargate/netsuite-etl_SubPaymentHistoryETL_production
WOULD-DELETE /aws/fargate/netsuite-etl_ServiceRecordsETL_production
WOULD-DELETE /aws/fargate/netsuite-etl_ServiceOrdersUpdatesETL_demo
WOULD-DELETE /aws/fargate/netsuite-etl_ServiceOrdersUpdatesETL_staging
WOULD-DELETE /aws/fargate/netsuite-etl_VendorsETL_beta
WOULD-DELETE /aws/fargate/netsuite-etl_ServiceOrdersETL_demo
WOULD-DELETE /aws/fargate/netsuite-etl_VendorsETL_demo
WOULD-DELETE /aws/fargate/netsuite-etl_ServiceOrdersETL_production
WOULD-DELETE /aws/fargate/netsuite-etl_VendorsETL_production
WOULD-DELETE /aws/fargate/netsuite-etl_LocationsETL_beta
WOULD-DELETE /aws/fargate/netsuite-etl_VendorsETL_staging
WOULD-DELETE /aws/fargate/netsuite-etl_SubPaymentHistoryETL_staging
WOULD-DELETE /aws/fargate/netsuite_budget_records_producer_staging
WOULD-DELETE /aws/fargate/netsuite_budget_wage_rates_producer_production
WOULD-DELETE /aws/fargate/netsuite_cases_producer_staging
WOULD-DELETE /aws/fargate/netsuite_erp_budget_records_producer_staging
WOULD-DELETE /aws/fargate/netsuite_budget_records_producer_production
WOULD-DELETE /aws/fargate/netsuite_erp_budget_wage_rates_producer_staging
WOULD-DELETE /aws/fargate/netsuite_erp_budget_records_producer_test1
WOULD-DELETE /aws/fargate/netsuite_budget_wage_rates_producer_staging
WOULD-DELETE /aws/fargate/netsuite_erp_cases_producer_staging
WOULD-DELETE /aws/fargate/netsuite_erp_gl_transactions_producer_test1
WOULD-DELETE /aws/fargate/netsuite_erp_budget_wage_rates_producer_test1
WOULD-DELETE /aws/fargate/netsuite_erp_service_performances_producer_staging
WOULD-DELETE /aws/fargate/netsuite_erp_locations_producer_staging
WOULD-DELETE /aws/fargate/netsuite_vendors_producer_production
KEEP         /aws/fargate/scheduler-beta-karafka_stats
KEEP         /aws/fargate/scheduler-beta-shadow_users_sync
KEEP         /aws/fargate/scheduler-beta-sync_wotc
KEEP         /aws/fargate/scheduler-beta-fresh_service_import
KEEP         /aws/fargate/scheduler-beta-karafka_user_data
KEEP         /aws/fargate/scheduler-demo-business_units_import
KEEP         /aws/fargate/scheduler-beta-karafka
KEEP         /aws/fargate/scheduler-beta-location_managers_import
KEEP         /aws/fargate/scheduler-beta-shadow_users_position_update
KEEP         /aws/fargate/scheduler-beta-karafka_case_status
KEEP         /aws/fargate/scheduler-beta-web
KEEP         /aws/fargate/scheduler-beta-karafka_user-data
KEEP         /aws/fargate/scheduler-demo-case_status_change_consumer
KEEP         /aws/fargate/scheduler-demo-deduplicate_location_managers
KEEP         /aws/fargate/scheduler-beta-user_data_message_consumer
KEEP         /aws/fargate/scheduler-demo-delayed_job_checker
KEEP         /aws/fargate/scheduler-demo-alerts_confirmation
KEEP         /aws/fargate/scheduler-demo-delayed_jobs
KEEP         /aws/fargate/scheduler-demo-export_emergency_contacts_for_workday
KEEP         /aws/fargate/scheduler-demo-export_employees_for_workday
KEEP         /aws/fargate/scheduler-beta-migrate_and_seed
KEEP         /aws/fargate/scheduler-demo-export_wotc_forms
KEEP         /aws/fargate/scheduler-demo-fresh_service_import
KEEP         /aws/fargate/scheduler-demo-exports_for_workday
KEEP         /aws/fargate/scheduler-demo-job_titles_import
KEEP         /aws/fargate/scheduler-demo-karafka
KEEP         /aws/fargate/scheduler-demo-karafka_case-status
KEEP         /aws/fargate/scheduler-demo-karafka-stats
KEEP         /aws/fargate/scheduler-demo-karafka_case_status
KEEP         /aws/fargate/scheduler-demo-karafka_stats
KEEP         /aws/fargate/scheduler-demo-karafka_user_data
KEEP         /aws/fargate/scheduler-demo-location_managers_import
KEEP         /aws/fargate/scheduler-beta-managers_import
KEEP         /aws/fargate/scheduler-demo-onboarding_update
KEEP         /aws/fargate/scheduler-demo-sync_wotc
KEEP         /aws/fargate/scheduler-demo-target_hire_followup_reminder_mailer
KEEP         /aws/fargate/scheduler-demo-web
KEEP         /aws/fargate/scheduler-demo-karafka_tabletop_location_change
KEEP         /aws/fargate/scheduler-intst-export_wotc_forms
KEEP         /aws/fargate/scheduler-demo-karafka_user-data
KEEP         /aws/fargate/scheduler-intst-business_units_import
KEEP         /aws/fargate/scheduler-demo-target_hire_reminder_mailer
KEEP         /aws/fargate/scheduler-intst-exports_for_workday
KEEP         /aws/fargate/scheduler-intst-location_managers_import
KEEP         /aws/fargate/scheduler-intst-job_titles_import
KEEP         /aws/fargate/scheduler-intst-web
KEEP         /aws/fargate/scheduler-intst-user_data_message_consumer
KEEP         /aws/fargate/scheduler-demo-managers_import
KEEP         /aws/fargate/scheduler-production-alerts_confirmation
KEEP         /aws/fargate/scheduler-intst-onboarding_update
KEEP         /aws/fargate/scheduler-intst-alerts_confirmation
KEEP         /aws/fargate/scheduler-demo-migrate_and_seed
KEEP         /aws/fargate/scheduler-production-export_employees_for_workday
KEEP         /aws/fargate/scheduler-production-backfill_attestation_submissions
KEEP         /aws/fargate/scheduler-intst-sync_wotc
KEEP         /aws/fargate/scheduler-production-karafka-stats
KEEP         /aws/fargate/scheduler-production-karafka_user-data
KEEP         /aws/fargate/scheduler-production-sync_wotc
KEEP         /aws/fargate/scheduler-production-user_data_message_consumer
KEEP         /aws/fargate/scheduler-staging-karafka-stats
KEEP         /aws/fargate/scheduler-staging-target_hire_followup_reminder_mailer
KEEP         /aws/fargate/scheduler-staging-job_titles_import
KEEP         /aws/fargate/scheduler-staging-shadow_users_sync
KEEP         /aws/fargate/scheduler-staging-sync_wotc
KEEP         /aws/fargate/scheduler-staging-user_data_message_consumer
KEEP         /aws/fargate/scheduler-staging-web
KEEP         /aws/fargate/scheduler-staging-managers_import
KEEP         /aws/fargate/scheduler-staging-target_hire_reminder_mailer
KEEP         /aws/fargate/scheduler-staging-karafka
KEEP         /aws/fargate/scheduler-staging-fresh_service_import
WOULD-DELETE /aws/fargate/sonarqube-staging-web
KEEP         /aws/fargate/tabletop-beta-archive_employee_punches
KEEP         /aws/fargate/scheduler-staging-migrate_and_seed
KEEP         /aws/fargate/scheduler-staging-karafka_case_status
KEEP         /aws/fargate/scheduler-staging-shadow_users_position_update
KEEP         /aws/fargate/scheduler-staging-karafka_tabletop_location_change
KEEP         /aws/fargate/tabletop-beta-archive_labor_budget
KEEP         /aws/fargate/tabletop-beta-archive_labor_budgets
KEEP         /aws/fargate/tabletop-beta-archive_service_orders
KEEP         /aws/fargate/tabletop-beta-archive_matched_vendor_punches
KEEP         /aws/fargate/tabletop-beta-archive_timeslips
KEEP         /aws/fargate/scheduler-staging-karafka_stats
KEEP         /aws/fargate/scheduler-staging-location_managers_import
KEEP         /aws/fargate/tabletop-beta-check_labor_records
KEEP         /aws/fargate/tabletop-beta-copy_shifts
KEEP         /aws/fargate/scheduler-staging-onboarding_update
KEEP         /aws/fargate/scheduler-staging-karafka_user_data
KEEP         /aws/fargate/tabletop-beta-delayed_jobs_runner
KEEP         /aws/fargate/tabletop-beta-duplicate_condition_reporter
KEEP         /aws/fargate/tabletop-beta-delayed_job_checker
KEEP         /aws/fargate/tabletop-beta-archive_shifts
KEEP         /aws/fargate/tabletop-beta-delete_expired_location_alert_conditions
KEEP         /aws/fargate/tabletop-beta-employee_consumer
KEEP         /aws/fargate/tabletop-beta-erp_import_missing_epicor_payments
KEEP         /aws/fargate/tabletop-beta-create_next_weeks_shifts
KEEP         /aws/fargate/tabletop-beta-change_publisher
KEEP         /aws/fargate/tabletop-beta-etl_customer_location_tag_builder
KEEP         /aws/fargate/tabletop-beta-etl_employee_workday
KEEP         /aws/fargate/tabletop-beta-etl_hierarchy_current
KEEP         /aws/fargate/tabletop-beta-etl_hierarchy_historical
KEEP         /aws/fargate/tabletop-beta-etl_customer_group
KEEP         /aws/fargate/tabletop-beta-etl_location_week_scheduled_hours
KEEP         /aws/fargate/tabletop-beta-deactivate_parent_and_customer_groups_job
KEEP         /aws/fargate/tabletop-beta-etl_ivr_feature_flag
KEEP         /aws/fargate/tabletop-beta-erp_migrate_historical_checks
KEEP         /aws/fargate/tabletop-beta-ghost_inspector_data_populate_my_projects_scheduled_completed
KEEP         /aws/fargate/tabletop-beta-kafka_location_change_publisher
KEEP         /aws/fargate/tabletop-beta-labor_budget_consumer
KEEP         /aws/fargate/tabletop-beta-prune_old_hierarchy_data_and_tcc_stats_job
KEEP         /aws/fargate/tabletop-beta-import_wage_caps
KEEP         /aws/fargate/tabletop-beta-punch_watcher
KEEP         /aws/fargate/tabletop-beta-punch_publishing_delayed_jobs_runner
KEEP         /aws/fargate/tabletop-beta-netsuite_employee_consumer
KEEP         /aws/fargate/tabletop-beta-location_refresh_punch_counts
KEEP         /aws/fargate/tabletop-beta-purge_phone_number_lookups
KEEP         /aws/fargate/tabletop-beta-location_status_refresher_daily
KEEP         /aws/fargate/tabletop-beta-purge_process_executions
KEEP         /aws/fargate/tabletop-beta-logging_test_job
KEEP         /aws/fargate/tabletop-beta-karafka_consumer
KEEP         /aws/fargate/tabletop-beta-location_wage_rate_consumer
KEEP         /aws/fargate/tabletop-beta-location_reporting_refresher
KEEP         /aws/fargate/tabletop-beta-reconcile_parent_customer_groups_job
KEEP         /aws/fargate/tabletop-beta-ns_entity_consumer
KEEP         /aws/fargate/tabletop-beta-migrate_and_seed
KEEP         /aws/fargate/tabletop-beta-karafka-stats
KEEP         /aws/fargate/tabletop-beta-refresh_views
KEEP         /aws/fargate/tabletop-beta-service_order_updater_job
KEEP         /aws/fargate/tabletop-beta-service_record_updater_job
KEEP         /aws/fargate/tabletop-beta-periodic_labor_budget_consumer
KEEP         /aws/fargate/tabletop-beta-location_status_refresher_weekly
KEEP         /aws/fargate/tabletop-beta-user_data_message_karafka_consumer
KEEP         /aws/fargate/tabletop-beta-user_data_message_consumer
KEEP         /aws/fargate/tabletop-beta-vendor_location_updater_job
KEEP         /aws/fargate/tabletop-beta-invalid_condition_reporter
KEEP         /aws/fargate/tabletop-beta-location_attribute_refresher
KEEP         /aws/fargate/tabletop-beta-vendor_punch_matcher
KEEP         /aws/fargate/tabletop-beta-web
KEEP         /aws/fargate/tabletop-data-consumer-beta-cases_consumer
KEEP         /aws/fargate/tabletop-data-consumer-beta-cases_consumer-v2
KEEP         /aws/fargate/tabletop-data-consumer-beta-kbs_labor_details_consumer
KEEP         /aws/fargate/tabletop-data-consumer-beta-minimum_wages_consumer-v2
KEEP         /aws/fargate/tabletop-data-consumer-beta-subscription_items_consumer-v2
KEEP         /aws/fargate/tabletop-data-consumer-beta-vendor_payments_and_credits_consumer
KEEP         /aws/fargate/tabletop-data-consumer-beta-service_performances_consumer-v2
KEEP         /aws/fargate/tabletop-data-consumer-beta-service_orders_consumer
KEEP         /aws/fargate/tabletop-data-consumer-beta-minimum_wages_consumer
KEEP         /aws/fargate/tabletop-data-consumer-beta-vendors_consumer
KEEP         /aws/fargate/tabletop-data-consumer-beta-kbs_labor_details_consumer-v2
KEEP         /aws/fargate/tabletop-data-consumer-beta-vendors_consumer-v2
KEEP         /aws/fargate/tabletop-data-consumer-beta-subscription_items_consumer
KEEP         /aws/fargate/tabletop-data-consumer-beta-service_performances_consumer
KEEP         /aws/fargate/tabletop-data-consumer-beta-viso_sales_orders_consumer
KEEP         /aws/fargate/tabletop-data-consumer-beta-vendor_bill_items_consumer
KEEP         /aws/fargate/tabletop-data-consumer-demo-minimum_wages_consumer
KEEP         /aws/fargate/tabletop-data-consumer-beta-vendor_bill_items_consumer-v2
KEEP         /aws/fargate/tabletop-data-consumer-demo-service_performances_consumer
KEEP         /aws/fargate/tabletop-data-consumer-demo-locations_consumer-v2
KEEP         /aws/fargate/tabletop-data-consumer-demo-service_records_consumer
KEEP         /aws/fargate/tabletop-data-consumer-demo-service_orders_consumer
KEEP         /aws/fargate/tabletop-data-consumer-demo-service_records_consumer-v2
KEEP         /aws/fargate/tabletop-data-consumer-demo-cases_consumer-v2
KEEP         /aws/fargate/tabletop-data-consumer-demo-vendor_bill_items_consumer
KEEP         /aws/fargate/tabletop-data-consumer-demo-vendor_payments_and_credits_consumer
KEEP         /aws/fargate/tabletop-data-consumer-demo-vendor_bill_items_consumer-v2
KEEP         /aws/fargate/tabletop-data-consumer-beta-vendor_remittances_consumer-v2
KEEP         /aws/fargate/tabletop-data-consumer-demo-subscription_items_consumer
KEEP         /aws/fargate/tabletop-data-consumer-demo-vendor_remittances_consumer
KEEP         /aws/fargate/tabletop-data-consumer-demo-vendors_consumer
KEEP         /aws/fargate/tabletop-data-consumer-demo-cases_consumer
KEEP         /aws/fargate/tabletop-data-consumer-demo-viso_sales_orders_consumer
KEEP         /aws/fargate/tabletop-data-consumer-production-minimum_wages_consumer-v2
KEEP         /aws/fargate/tabletop-data-consumer-production-service_performances_consumer
KEEP         /aws/fargate/tabletop-data-consumer-production-subscription_items_consumer-v2
KEEP         /aws/fargate/tabletop-data-consumer-staging-locations_consumer
KEEP         /aws/fargate/tabletop-data-consumer-production-subscription_items_consumer
KEEP         /aws/fargate/tabletop-data-consumer-staging-service_orders_consumer
KEEP         /aws/fargate/tabletop-data-consumer-staging-cases_consumer-v2
KEEP         /aws/fargate/tabletop-data-consumer-production-vendor_payments_and_credits_consumer
KEEP         /aws/fargate/tabletop-data-consumer-staging-service_performances_consumer-v2
KEEP         /aws/fargate/tabletop-data-consumer-production-vendor_remittances_consumer-v2
KEEP         /aws/fargate/tabletop-data-consumer-staging-locations_consumer-v2
KEEP         /aws/fargate/tabletop-data-consumer-staging-new_cases_consumer
KEEP         /aws/fargate/tabletop-data-consumer-staging-cases_consumer
KEEP         /aws/fargate/tabletop-data-consumer-staging-kbs_labor_details_consumer-v2
KEEP         /aws/fargate/tabletop-data-consumer-staging-minimum_wages_consumer
KEEP         /aws/fargate/tabletop-data-consumer-staging-service_records_consumer-v2
KEEP         /aws/fargate/tabletop-data-consumer-staging-subscription_items_consumer
KEEP         /aws/fargate/tabletop-data-consumer-staging-service_records_consumer
KEEP         /aws/fargate/tabletop-data-consumer-staging-service_performances_consumer
KEEP         /aws/fargate/tabletop-data-consumer-staging-service_orders_consumer-v2
KEEP         /aws/fargate/tabletop-data-consumer-staging-subscription_items_consumer-v2
KEEP         /aws/fargate/tabletop-data-consumer-staging-vendor_bill_items_consumer-v2
KEEP         /aws/fargate/tabletop-data-consumer-staging-vendor_bill_items_consumer
KEEP         /aws/fargate/tabletop-data-consumer-staging-viso_sales_orders_consumer
KEEP         /aws/fargate/tabletop-data-consumer-staging-viso_sales_orders_consumer-v2
KEEP         /aws/fargate/tabletop-demo-archive_employee_punches
KEEP         /aws/fargate/tabletop-demo-archive_labor_budgets
KEEP         /aws/fargate/tabletop-demo-archive_service_orders
KEEP         /aws/fargate/tabletop-demo-archive_shifts
KEEP         /aws/fargate/tabletop-demo-archive_vendor_punches
KEEP         /aws/fargate/tabletop-data-consumer-staging-tabletop_cases_consumer
KEEP         /aws/fargate/tabletop-data-consumer-staging-vendor_remittances_consumer-v2
KEEP         /aws/fargate/tabletop-demo-archive_labor_budget
KEEP         /aws/fargate/tabletop-data-consumer-staging-vendor_remittances_consumer
KEEP         /aws/fargate/tabletop-data-consumer-staging-minimum_wages_consumer-v2
KEEP         /aws/fargate/tabletop-data-consumer-staging-vendors_consumer-v2
KEEP         /aws/fargate/tabletop-data-consumer-staging-vendor_payments_and_credits_consumer-v2
KEEP         /aws/fargate/tabletop-demo-archive_timeslips
KEEP         /aws/fargate/tabletop-demo-deactivate_duplicate_locations_job
KEEP         /aws/fargate/tabletop-demo-duplicate_employee_condition_reporter_all_for_affected_sites
KEEP         /aws/fargate/tabletop-demo-check_labor_records
KEEP         /aws/fargate/tabletop-demo-confirmation_watcher
KEEP         /aws/fargate/tabletop-demo-employee_consumer
KEEP         /aws/fargate/tabletop-demo-deactivate_parent_and_customer_groups_job
KEEP         /aws/fargate/tabletop-demo-archive_labor_details
KEEP         /aws/fargate/tabletop-demo-etl_daily
KEEP         /aws/fargate/tabletop-demo-erp_data_refresher
KEEP         /aws/fargate/tabletop-demo-copy_shifts
KEEP         /aws/fargate/tabletop-data-consumer-staging-vendors_consumer
KEEP         /aws/fargate/tabletop-demo-delete_expired_location_alert_conditions
KEEP         /aws/fargate/tabletop-demo-etl_employee_workday
KEEP         /aws/fargate/tabletop-demo-etl_employee
KEEP         /aws/fargate/tabletop-demo-etl_business_unit
KEEP         /aws/fargate/tabletop-demo-archive_location_alert_conditions_changed
KEEP         /aws/fargate/tabletop-demo-etl_frequent
KEEP         /aws/fargate/tabletop-demo-etl_hierarchy_historical
KEEP         /aws/fargate/tabletop-demo-etl_hierarchy_current
KEEP         /aws/fargate/tabletop-demo-etl_customer_location_tag_builder
KEEP         /aws/fargate/tabletop-demo-etl_ivr_feature_flag
KEEP         /aws/fargate/tabletop-demo-delayed_jobs_runner
KEEP         /aws/fargate/tabletop-demo-etl_customer_group
KEEP         /aws/fargate/tabletop-demo-etl_kpi
KEEP         /aws/fargate/tabletop-demo-check_punch_arrival
KEEP         /aws/fargate/tabletop-demo-etl_labor
KEEP         /aws/fargate/tabletop-demo-etl_location
KEEP         /aws/fargate/tabletop-demo-etl_location_week_scheduled_hours
KEEP         /aws/fargate/tabletop-demo-duplicate_employee_condition_reporter
KEEP         /aws/fargate/tabletop-demo-etl_wage_cap
KEEP         /aws/fargate/tabletop-demo-etl_parent_group
KEEP         /aws/fargate/tabletop-demo-etl_punch_job
KEEP         /aws/fargate/tabletop-demo-external_vendor_punch_consumer
KEEP         /aws/fargate/tabletop-demo-delayed_job_checker
KEEP         /aws/fargate/tabletop-demo-ghost_inspector_data_populate_my_projects_scheduled_completed
KEEP         /aws/fargate/tabletop-demo-ghost_inspector_data_populate_vendor_projects
KEEP         /aws/fargate/tabletop-demo-ghost_inspector_data_populate_vendor_payments
KEEP         /aws/fargate/tabletop-demo-etl_punch_project
KEEP         /aws/fargate/tabletop-demo-ghost_inspector_data_populate_my_projects_cases
KEEP         /aws/fargate/tabletop-demo-ghost_inspector_data_populate_vendor_service_orders_to_schedule
KEEP         /aws/fargate/tabletop-demo-ghost_inspector_data_populate_my_projects_unscheduled_uncompleted
KEEP         /aws/fargate/tabletop-demo-hss_location_consumer
KEEP         /aws/fargate/tabletop-demo-hss_assignment_consumer
KEEP         /aws/fargate/tabletop-demo-ghost_inspector_data_populate_vendor_bills
KEEP         /aws/fargate/tabletop-demo-hss_employee_consumer
KEEP         /aws/fargate/tabletop-demo-import_wage_caps
KEEP         /aws/fargate/tabletop-demo-karafka_consumer
KEEP         /aws/fargate/tabletop-demo-location_reporting_refresher
KEEP         /aws/fargate/tabletop-demo-location_attribute_refresher
KEEP         /aws/fargate/tabletop-demo-location_status_refresher_daily
KEEP         /aws/fargate/tabletop-demo-location_status_refresher_weekly
KEEP         /aws/fargate/tabletop-demo-kafka_location_change_publisher
KEEP         /aws/fargate/tabletop-demo-ghost_inspector_data_populate_vendor_service_performances
KEEP         /aws/fargate/tabletop-demo-ns_entity_consumer
KEEP         /aws/fargate/tabletop-demo-punch_publishing_delayed_jobs_runner
KEEP         /aws/fargate/tabletop-demo-labor_budget_consumer
KEEP         /aws/fargate/tabletop-demo-logging_test_job
KEEP         /aws/fargate/tabletop-demo-purge_phone_number_lookups
KEEP         /aws/fargate/tabletop-demo-netsuite_employee_consumer
KEEP         /aws/fargate/tabletop-demo-reconcile_parent_customer_groups_job
KEEP         /aws/fargate/tabletop-intst-archive_labor_budget
KEEP         /aws/fargate/tabletop-demo-location_refresh_punch_counts
KEEP         /aws/fargate/tabletop-demo-vendor_location_updater_job
KEEP         /aws/fargate/tabletop-intst-copy_shifts
KEEP         /aws/fargate/tabletop-intst-etl_location
KEEP         /aws/fargate/tabletop-intst-hss_location_consumer
KEEP         /aws/fargate/tabletop-intst-ghost_inspector_data_populate_vendor_projects
KEEP         /aws/fargate/tabletop-intst-punch_publishing_delayed_jobs_runner
KEEP         /aws/fargate/tabletop-intst-purge_phone_number_lookups
KEEP         /aws/fargate/tabletop-intst-punch_watcher
KEEP         /aws/fargate/tabletop-intst-location_wage_rate_consumer
KEEP         /aws/fargate/tabletop-intst-purge_process_executions
KEEP         /aws/fargate/tabletop-intst-hss_employee_consumer
KEEP         /aws/fargate/tabletop-intst-reconcile_parent_customer_groups_job
KEEP         /aws/fargate/tabletop-intst-location_refresh_punch_counts
KEEP         /aws/fargate/tabletop-intst-refresh_views
KEEP         /aws/fargate/tabletop-intst-location_status_refresher_weekly
KEEP         /aws/fargate/tabletop-intst-service_record_updater_job
KEEP         /aws/fargate/tabletop-intst-invalid_condition_reporter
KEEP         /aws/fargate/tabletop-intst-user_data_message_consumer
KEEP         /aws/fargate/tabletop-intst-vendor_bill_items_correct_vendor_bill_item_data
KEEP         /aws/fargate/tabletop-intst-labor_budget_consumer
KEEP         /aws/fargate/tabletop-intst-vendor_location_updater_job
KEEP         /aws/fargate/tabletop-intst-hss_assignment_consumer
KEEP         /aws/fargate/tabletop-intst-vendor_punch_matcher
KEEP         /aws/fargate/tabletop-intst-location_status_refresher_daily
KEEP         /aws/fargate/tabletop-production-archive_labor_budgets
KEEP         /aws/fargate/tabletop-production-archive_location_alert_conditions_changed
KEEP         /aws/fargate/tabletop-intst-service_order_updater_job
KEEP         /aws/fargate/tabletop-production-archive_service_orders
KEEP         /aws/fargate/tabletop-production-archive_shifts
KEEP         /aws/fargate/tabletop-intst-web
KEEP         /aws/fargate/tabletop-production-change_publisher
KEEP         /aws/fargate/tabletop-production-archive_labor_details
KEEP         /aws/fargate/tabletop-production-copy_shifts
KEEP         /aws/fargate/tabletop-production-check_punch_arrival
KEEP         /aws/fargate/tabletop-production-confirmation_watcher
KEEP         /aws/fargate/tabletop-production-archive_employee_punches
KEEP         /aws/fargate/tabletop-production-delayed_jobs_runner
KEEP         /aws/fargate/tabletop-production-duplicate_condition_reporter
KEEP         /aws/fargate/tabletop-production-duplicate_employee_condition_reporter
KEEP         /aws/fargate/tabletop-production-erp_migrate_historical_checks
KEEP         /aws/fargate/tabletop-production-employee_consumer
KEEP         /aws/fargate/tabletop-production-etl_business_unit
KEEP         /aws/fargate/tabletop-production-deactivate_parent_and_customer_groups_job
KEEP         /aws/fargate/tabletop-production-deactivate_duplicate_locations_job
KEEP         /aws/fargate/tabletop-production-etl_employee_workday
KEEP         /aws/fargate/tabletop-production-delete_expired_location_alert_conditions
KEEP         /aws/fargate/tabletop-production-etl_ivr_feature_flag
KEEP         /aws/fargate/tabletop-production-etl_customer_group
KEEP         /aws/fargate/tabletop-production-archive_timeslips
KEEP         /aws/fargate/tabletop-production-etl_frequent
KEEP         /aws/fargate/tabletop-production-erp_import_missing_epicor_payments
KEEP         /aws/fargate/tabletop-production-etl_punch_project
KEEP         /aws/fargate/tabletop-production-ghost_inspector_data_populate_vendor_projects
KEEP         /aws/fargate/tabletop-production-etl_hierarchy_current
KEEP         /aws/fargate/tabletop-production-ns_entity_consumer
KEEP         /aws/fargate/tabletop-production-location_status_refresher_daily
KEEP         /aws/fargate/tabletop-production-prune_old_hierarchy_data_and_tcc_stats_job
KEEP         /aws/fargate/tabletop-production-punch_watcher
KEEP         /aws/fargate/tabletop-production-refresh_views
KEEP         /aws/fargate/tabletop-production-periodic_labor_budget_consumer
KEEP         /aws/fargate/tabletop-production-logging_test_job
KEEP         /aws/fargate/tabletop-production-user_data_message_consumer
KEEP         /aws/fargate/tabletop-production-service_order_updater_job
KEEP         /aws/fargate/tabletop-production-location_refresh_punch_counts
KEEP         /aws/fargate/tabletop-production-purge_phone_number_lookups
KEEP         /aws/fargate/tabletop-production-migrate_and_seed
KEEP         /aws/fargate/tabletop-production-scheduled_delayed_jobs
KEEP         /aws/fargate/tabletop-production-user_data_message_karafka_consumer
KEEP         /aws/fargate/tabletop-production-service_record_updater_job
KEEP         /aws/fargate/tabletop-production-vendor_bill_items_correct_vendor_bill_item_data
KEEP         /aws/fargate/tabletop-production-vendor_punch_auto_creator
KEEP         /aws/fargate/tabletop-production-web2
KEEP         /aws/fargate/tabletop-production-vendor_punch_matcher
KEEP         /aws/fargate/tabletop-staging-archive_employee_punches
KEEP         /aws/fargate/tabletop-staging-archive_labor_budget
KEEP         /aws/fargate/tabletop-staging-archive_labor_budgets
KEEP         /aws/fargate/tabletop-staging-archive_location_alert_conditions_changed
KEEP         /aws/fargate/tabletop-staging-deactivate_duplicate_locations_job
KEEP         /aws/fargate/tabletop-production-vendor_location_updater_job
KEEP         /aws/fargate/tabletop-staging-archive_timeslips
KEEP         /aws/fargate/tabletop-staging-archive_labor_details
KEEP         /aws/fargate/tabletop-staging-change_publisher
KEEP         /aws/fargate/tabletop-staging-archive_location_reporting
KEEP         /aws/fargate/tabletop-staging-db_switch_export_cursors
KEEP         /aws/fargate/tabletop-staging-confirmation_watcher
KEEP         /aws/fargate/tabletop-staging-duplicate_condition_reporter
KEEP         /aws/fargate/tabletop-staging-erp_data_refresher
KEEP         /aws/fargate/tabletop-staging-etl_hierarchy_historical
KEEP         /aws/fargate/tabletop-staging-erp_import_missing_epicor_payments
KEEP         /aws/fargate/tabletop-staging-export_phone_stipend_attestations
KEEP         /aws/fargate/tabletop-staging-etl_labor
KEEP         /aws/fargate/tabletop-staging-etl_customer_group
KEEP         /aws/fargate/tabletop-staging-etl_wage_cap
KEEP         /aws/fargate/tabletop-staging-etl_location
KEEP         /aws/fargate/tabletop-staging-external_vendor_punch_consumer
KEEP         /aws/fargate/tabletop-staging-ghost_inspector_data
KEEP         /aws/fargate/tabletop-staging-duplicate_employee_condition_reporter
KEEP         /aws/fargate/tabletop-staging-etl_hierarchy_current
KEEP         /aws/fargate/tabletop-staging-etl_punch_project
KEEP         /aws/fargate/tabletop-staging-ghost_inspector_data_populate_my_projects_cases
KEEP         /aws/fargate/tabletop-staging-erp_migrate_historical_checks
KEEP         /aws/fargate/tabletop-staging-etl_customer_location_tag_builder
KEEP         /aws/fargate/tabletop-staging-ghost_inspector_data_populate_my_projects_unscheduled_uncompleted
KEEP         /aws/fargate/tabletop-staging-ghost_inspector_data_populate_vendor_service_orders_to_schedule
KEEP         /aws/fargate/tabletop-staging-ghost_inspector_data_populate_vendor_service_performances
KEEP         /aws/fargate/tabletop-staging-hss_assignment_consumer
KEEP         /aws/fargate/tabletop-staging-etl_frequent
KEEP         /aws/fargate/tabletop-staging-etl_kpi
KEEP         /aws/fargate/tabletop-staging-hss_location_consumer
KEEP         /aws/fargate/tabletop-staging-invalid_condition_reporter
KEEP         /aws/fargate/tabletop-staging-karafka
KEEP         /aws/fargate/tabletop-staging-karafka_consumer
KEEP         /aws/fargate/tabletop-staging-labor_budget_consumer
KEEP         /aws/fargate/tabletop-staging-location_wage_rate_consumer
KEEP         /aws/fargate/tabletop-staging-purge_phone_number_lookups
KEEP         /aws/fargate/tabletop-staging-punch_watcher
KEEP         /aws/fargate/tabletop-staging-kronos_punch_event_log_consumer
KEEP         /aws/fargate/tabletop-staging-refresh_views
KEEP         /aws/fargate/tabletop-staging-migrate_location_alert_conditions
KEEP         /aws/fargate/tabletop-staging-netsuite_employee_consumer
KEEP         /aws/fargate/tabletop-staging-service_record_updater_job
KEEP         /aws/fargate/tabletop-staging-service_order_updater_job
KEEP         /aws/fargate/tabletop-staging-purge_process_executions
KEEP         /aws/fargate/tabletop-staging-user_data_message_consumer
KEEP         /aws/fargate/tabletop-staging-prune_old_hierarchy_data_and_tcc_stats_job
KEEP         /aws/fargate/tabletop-staging-user_data_message_karafka_consumer
KEEP         /aws/fargate/tabletop-staging-vendor_bill_items_correct_vendor_bill_item_data
KEEP         /aws/fargate/tabletop-staging-location_status_refresher_daily
KEEP         /aws/fargate/tabletop-staging-punch_publishing_delayed_jobs_runner
KEEP         /aws/fargate/tabletop-staging-vendor_location_updater_job
KEEP         /aws/fargate/tabletop-staging-restore_vendor_punches
KEEP         /aws/fargate/tabletop-staging-reconcile_parent_customer_groups_job
KEEP         /aws/fargate/tabletop-staging-ns_entity_consumer
KEEP         /aws/fargate/tabletop-staging-vendor_punch_matcher
KEEP         /aws/fargate/tabletop-staging-web
KEEP         /aws/fargate/tabletop_cases_consumer-intst
KEEP         /aws/fargate/tabletop_cases_consumer-demo
KEEP         /aws/fargate/tabletop_cases_consumer-beta
KEEP         /aws/fargate/tabletop_cases_consumer-production
KEEP         /aws/fargate/tabletop_kbs_labor_detail_consumer-staging
KEEP         /aws/fargate/tabletop-staging-web2
KEEP         /aws/fargate/tabletop_location_consumer-beta
KEEP         /aws/fargate/tabletop_location_consumer-production
KEEP         /aws/fargate/tabletop_location_consumer-staging
KEEP         /aws/fargate/tabletop_location_consumer-demo
KEEP         /aws/fargate/tabletop-staging-vendor_punch_auto_creator
KEEP         /aws/fargate/tabletop_cases_consumer-staging
KEEP         /aws/fargate/tabletop_service_order_consumer-intst
KEEP         /aws/fargate/tabletop_kbs_labor_detail_consumer-beta
KEEP         /aws/fargate/tabletop_kbs_labor_detail_consumer-production
KEEP         /aws/fargate/tabletop_service_order_consumer-production
KEEP         /aws/fargate/tabletop_service_record_consumer-demo
KEEP         /aws/fargate/tabletop_kbs_labor_detail_consumer-demo
KEEP         /aws/fargate/tabletop_service_order_consumer-beta
KEEP         /aws/fargate/tabletop_vfs_labor_detail_consumer-production
KEEP         /aws/fargate/tabletop_service_record_consumer-production
WOULD-DELETE /aws/fargate/tasks-staging-web
KEEP         /aws/fargate/vendor-beta-migrate_and_seed-v2
KEEP         /aws/fargate/vendor-beta-user_data_message_consumer
KEEP         /aws/fargate/tabletop_service_order_consumer-staging
KEEP         /aws/fargate/vendor-demo-karafka_stats
KEEP         /aws/fargate/vendor-beta-user_populator-v2
KEEP         /aws/fargate/vendor-beta-karafka_stats
KEEP         /aws/fargate/vendor-demo-user_populator
KEEP         /aws/fargate/vendor-demo-user_populator-v2
KEEP         /aws/fargate/vendor-production-karafka_stats
KEEP         /aws/fargate/vendor-production-karafka_install
KEEP         /aws/fargate/vendor-demo-migrate_and_seed-v2
KEEP         /aws/fargate/vendor-production-user_populator
KEEP         /aws/fargate/vendor-staging-user_populator
KEEP         /aws/fargate/vendor-staging-user_data_message_consumer
WOULD-DELETE /aws/fargate/wasaga-production-site_deleter
WOULD-DELETE /aws/fargate/vfs_labor_details_producer_production
WOULD-DELETE /aws/fargate/wasaga-staging-site_sync
WOULD-DELETE /aws/fargate/wasaga-staging-site_deleter
WOULD-DELETE /aws/fargate/wasaga-staging-vendor_notifier
WOULD-DELETE /aws/fargate/wasaga-staging-weather_fetcher
WOULD-DELETE /aws/fargate/wasaga-staging-customer_notifier
WOULD-DELETE /aws/fargate/wasaga-production-customer_notifier
WOULD-DELETE /aws/fargate/workday-producers/employees_producer_production
WOULD-DELETE /aws/fargate/wasaga-production-site_sync
WOULD-DELETE /aws/fargate/wasaga-production-vendor_notifier
WOULD-DELETE /aws/fargate/workday-producers/employees_producer_staging
KEEP         /aws/fargate/vendor-staging-user_populator-v2
WOULD-DELETE /aws/fargate/workday-producers/vaccination_statuses_producer_production
KEEP         /aws/fargate/vendor-staging-web-v2
WOULD-DELETE /aws/fargate/wasaga-production-weather_fetcher
WOULD-DELETE /aws/fargate/workday-producers/vaccinations_producer_staging
WOULD-DELETE /aws/lambda/KelsusTestStack-AsgDrainECSHookFunctionB279B86D-r7EYSJ6FTKBn
WOULD-DELETE /aws/lambda/KelsusTestingStack-AsgDrainECSHookFunctionB279B86D-LO4sGDZ6DdCR
WOULD-DELETE /aws/lambda/KelsusTestingStack-AsgDrainECSHookFunctionB279B86D-nFL5HTH9Ymmd
WOULD-DELETE /aws/lambda/MainRegionInfraDevStage-N-AdmNetworkRouteCustomRes-as0xplINuHZR
WOULD-DELETE /aws/lambda/MainRegionInfraDevStage-N-LogRetentionaae0aa3c5b4d-dqVVVxAc4a9H
WOULD-DELETE /aws/lambda/MainRegionInfraStgStage-N-AdmNetworkRouteCustomRes-ovOnMXoArX8w
WOULD-DELETE /aws/fargate/vfs_labor_details_producer_staging
KEEP         /aws/fargate/vendor-staging-web
WOULD-DELETE /aws/lambda/PublicAssetsStack-BucketNotificationsHandler050a05-CUA8EjROeYGd
WOULD-DELETE /aws/lambda/ReplicateConfig23Stack-LogRetentionaae0aa3c5b4d4f8-yP2ShNURYPHI
WOULD-DELETE /aws/lambda/SSTBootstrap-CustomS3AutoDeleteObjectsCustomResour-JxbKERptvRYn
WOULD-DELETE /aws/lambda/MainRegionInfraProdStage--AdmNetworkRouteCustomRes-4g1axVGwibQP
WOULD-DELETE /aws/lambda/MyLambdaFunction
WOULD-DELETE /aws/lambda/SSTBootstrap-MetadataHandlerBEE7179C-Hs0NKvK2nfgL
WOULD-DELETE /aws/lambda/Sarakiniko-production-BotActionsHandler
WOULD-DELETE /aws/lambda/ReplicateAppConfigStack-LogRetentionaae0aa3c5b4d4f-qf7FOPAIXUSN
WOULD-DELETE /aws/lambda/Sarakiniko-dev-SmartsheetSync
WOULD-DELETE /aws/lambda/Sarakiniko-production-LocationBuildingSync
WOULD-DELETE /aws/lambda/adm-network-route
WOULD-DELETE /aws/lambda/UsWest2AppConfigTest-AsgDrainECSHookFunctionB279B8-zXMiR8sMJnkt
WOULD-DELETE /aws/lambda/SumoCWLogsLambda-33c639e0-1d57-11e9-ae4a-0ae846f1e916
WOULD-DELETE /aws/lambda/Sarakiniko-production-LocationErpConsumer
WOULD-DELETE /aws/lambda/UsWest2-AsgDrainECSHookFunctionB279B86D-EHD6oJQr37xU
WOULD-DELETE /aws/lambda/UsWest2AppConfigTest-AsgDrainECSHookFunctionB279B8-LweOo5bKPl1j
WOULD-DELETE /aws/lambda/UsersInDatabasesReportSta-LogRetentionaae0aa3c5b4d-IaJtRnzCytUH
WOULD-DELETE /aws/lambda/amplify-billingportal-irf-CustomCDKBucketDeploymen-aolt66isQF9O
WOULD-DELETE /aws/lambda/UsWest2-AsgDrainECSHookFunctionB279B86D-mhV7oPCngmmc
WOULD-DELETE /aws/lambda/WorkSpacesCostOptimizer-CostOptimizerCreateTaskFun-3DGEX27Y0XF0
WOULD-DELETE /aws/lambda/amplify-billingportal-irf-CustomS3AutoDeleteObject-ZR4dhfsfzbOe
WOULD-DELETE /aws/lambda/amplify-billingportal-irf-CustomS3AutoDeleteObject-nDTbvJ9ixtZe
WOULD-DELETE /aws/lambda/Sarakiniko-production-RobotEventProducer
WOULD-DELETE /aws/lambda/amplify-billingportal-irf-TableManagerCustomProvid-dWYO4s8DqVwh
WOULD-DELETE /aws/lambda/ariba-scraper-production-scrapeInvoices
WOULD-DELETE /aws/lambda/SumoLogicPushDev
WOULD-DELETE /aws/lambda/SumoCWProcessDLQLambda-33c639e0-1d57-11e9-ae4a-0ae846f1e916
WOULD-DELETE /aws/lambda/SumoCWLogsLambda-4b232470-fa76-11e9-8ee2-0adc91850d78
WOULD-DELETE /aws/lambda/ariba-scraper-staging-scrapeInvoices
WOULD-DELETE /aws/lambda/ataylor-test-consumer
WOULD-DELETE /aws/lambda/audit-search-stg-audit-search
WOULD-DELETE /aws/lambda/Sarakiniko-production-SmartsheetSync
WOULD-DELETE /aws/lambda/ariba-scraper-dev-scrapeInvoices
WOULD-DELETE /aws/lambda/corrigo-web-automation-dev-poll_request
WOULD-DELETE /aws/lambda/cloudwatch-kafka-topics-report
WOULD-DELETE /aws/lambda/cluster-cleanup
WOULD-DELETE /aws/lambda/ctera-SubnetInfoFunction-9C4NOTN5FQIQ
WOULD-DELETE /aws/lambda/covid-aws-data-RedshiftLoadLambda-HLII9QSKIM6I
WOULD-DELETE /aws/lambda/amplify-billingportal-irf-TableManagerCustomProvid-yIUE9kQJ7ehN
WOULD-DELETE /aws/lambda/audit-search-prod-audit-search
WOULD-DELETE /aws/lambda/dev-nauset-stitch-dynamodb
WOULD-DELETE /aws/lambda/covid-aws-data-GetNewRevision-1D0SY3MAAKWUG
WOULD-DELETE /aws/lambda/dev-rollbar-ticket-status-sync
WOULD-DELETE /aws/lambda/auditSubscriptionMailer
WOULD-DELETE /aws/lambda/datadog-forwarder-ForwarderZipCopier-S7AMYN2MST92
WOULD-DELETE /aws/lambda/disaster-recovery-scripts-staging-failover
WOULD-DELETE /aws/lambda/dev-stitch-webhook
WOULD-DELETE /aws/lambda/flatrock-staging-web
WOULD-DELETE /aws/lambda/get-data-from-redis-staging
WOULD-DELETE /aws/lambda/disaster-recovery-scripts-production-safe_failback
WOULD-DELETE /aws/lambda/development-stitch-webhook
WOULD-DELETE /aws/lambda/flatrock-staging-punch_watcher
WOULD-DELETE /aws/lambda/get-redis-data-test1
WOULD-DELETE /aws/lambda/hatteras-staging-apiReviewLocationAlert
WOULD-DELETE /aws/lambda/ebs-snapshot-creator
WOULD-DELETE /aws/lambda/ebs-snapshot-manager
WOULD-DELETE /aws/lambda/hatteras-production-apiReviewLocationAlert
WOULD-DELETE /aws/lambda/durable-lambda-demo-dev-workflowDemo-v2
WOULD-DELETE /aws/lambda/hookipa-erp-dev-UpdateSalesOrderLine
WOULD-DELETE /aws/lambda/hookipa-erp-dev-AddVisoApproval
WOULD-DELETE /aws/lambda/forms-pdf-report-trigger
WOULD-DELETE /aws/lambda/disaster-recovery-scripts-production-safe_failover
WOULD-DELETE /aws/lambda/hookipa-erp-dev-UpdateViso
WOULD-DELETE /aws/lambda/hookipa-erp-dev-addMessageToConsolidatedInvoice
WOULD-DELETE /aws/lambda/hookipa-erp-dev-addMessageToInvoice
WOULD-DELETE /aws/lambda/hookipa-erp-dev-addNoteToServiceOrder
WOULD-DELETE /aws/lambda/hookipa-erp-dev-assignBannerLegacySrcIds
WOULD-DELETE /aws/lambda/hookipa-erp-dev-apiRouter
WOULD-DELETE /aws/lambda/hookipa-erp-dev-addNoteToCustomerCase
WOULD-DELETE /aws/lambda/forms-pdf-report-stg
WOULD-DELETE /aws/lambda/hookipa-erp-dev-assignKbsCustomerIds
WOULD-DELETE /aws/lambda/hookipa-erp-dev-assignParentCustomerLegacySrcIds
WOULD-DELETE /aws/lambda/durable-lambda-demo-dev-caseNoteProcessor
WOULD-DELETE /aws/lambda/flatrock-staging-delayed_jobs_runner
WOULD-DELETE /aws/lambda/disaster-recovery-scripts-staging-safe_failover
WOULD-DELETE /aws/lambda/hookipa-erp-dev-attachFileToSalesOrder
WOULD-DELETE /aws/lambda/hookipa-erp-dev-attachFileToServiceChangeRequest
WOULD-DELETE /aws/lambda/hookipa-erp-dev-attachFileToVendorBill
WOULD-DELETE /aws/lambda/hookipa-erp-dev-attachFileToCustomer
WOULD-DELETE /aws/lambda/hookipa-erp-dev-cloneInvoice
WOULD-DELETE /aws/lambda/hookipa-erp-dev-createCase
WOULD-DELETE /aws/lambda/hookipa-erp-dev-createJournalEntry
WOULD-DELETE /aws/lambda/hookipa-erp-dev-createServiceOrder
WOULD-DELETE /aws/lambda/hookipa-erp-dev-failRequest
WOULD-DELETE /aws/lambda/hookipa-erp-dev-eventQueueConsumer
WOULD-DELETE /aws/lambda/hookipa-erp-dev-deleteAndPrecacheNetsuiteLists
WOULD-DELETE /aws/lambda/hookipa-erp-dev-createTradesSalesOrder
WOULD-DELETE /aws/lambda/hookipa-erp-dev-getConsolidatedInvoicePDF
WOULD-DELETE /aws/lambda/hookipa-erp-dev-getLocationTypes
WOULD-DELETE /aws/lambda/hookipa-erp-dev-failedEventQueueConsumer
WOULD-DELETE /aws/lambda/hookipa-erp-dev-attachFileToLocation
WOULD-DELETE /aws/lambda/hookipa-erp-dev-getCaseOptions
WOULD-DELETE /aws/lambda/hookipa-erp-dev-createLocation
WOULD-DELETE /aws/lambda/hookipa-erp-dev-getPosPreferences
WOULD-DELETE /aws/lambda/hookipa-erp-dev-getInvoicePDF
WOULD-DELETE /aws/lambda/hookipa-erp-dev-createConsolidatedInvoice
WOULD-DELETE /aws/lambda/hookipa-erp-dev-processSalesforceCustomerEvents
WOULD-DELETE /aws/lambda/hookipa-erp-dev-updateConsolidatedInvoice
WOULD-DELETE /aws/lambda/hookipa-erp-dev-resetRequestTimeout
WOULD-DELETE /aws/lambda/hookipa-erp-dev-getServiceOrderStatuses
WOULD-DELETE /aws/lambda/hookipa-erp-dev-getConsolidatedInvoiceAttachments
WOULD-DELETE /aws/lambda/hookipa-erp-dev-updateCustomer
WOULD-DELETE /aws/lambda/hookipa-erp-dev-getInvoiceAttachments
WOULD-DELETE /aws/lambda/hookipa-erp-dev-updateCustomerCase
WOULD-DELETE /aws/lambda/hookipa-erp-production-addMessageToCustomerCase
WOULD-DELETE /aws/lambda/hookipa-erp-production-cloneInvoice
WOULD-DELETE /aws/lambda/hookipa-erp-production-attachFileToServiceChangeRequest
WOULD-DELETE /aws/lambda/hookipa-erp-production-createTradesSalesOrder
WOULD-DELETE /aws/lambda/hookipa-erp-production-createCase
WOULD-DELETE /aws/lambda/hookipa-erp-production-createJournalEntry
WOULD-DELETE /aws/lambda/hookipa-erp-production-attachFileToCase
WOULD-DELETE /aws/lambda/hookipa-erp-production-attachFileToSalesOrder
WOULD-DELETE /aws/lambda/hookipa-erp-production-attachFileToVendorBill
WOULD-DELETE /aws/lambda/hookipa-erp-production-createCreditMemo
WOULD-DELETE /aws/lambda/hookipa-erp-production-createConsolidatedInvoice
WOULD-DELETE /aws/lambda/hookipa-erp-production-failedEventQueueConsumer
WOULD-DELETE /aws/lambda/hookipa-erp-production-getCaseOptions
WOULD-DELETE /aws/lambda/hookipa-erp-production-cloneCreditMemo
WOULD-DELETE /aws/lambda/hookipa-erp-production-getConsolidatedInvoiceAttachments
WOULD-DELETE /aws/lambda/hookipa-erp-production-createReturnAuthorization
WOULD-DELETE /aws/lambda/hookipa-erp-production-getConsolidatedInvoicePDF
WOULD-DELETE /aws/lambda/hookipa-erp-production-assignKbsCustomerIds
WOULD-DELETE /aws/lambda/hookipa-erp-production-createServiceChangeRequest
WOULD-DELETE /aws/lambda/hookipa-erp-production-deleteAndPrecacheNetsuiteLists
WOULD-DELETE /aws/lambda/hookipa-erp-production-failRequest
WOULD-DELETE /aws/lambda/hookipa-erp-production-getPosStatuses
WOULD-DELETE /aws/lambda/hookipa-erp-production-getRequestStatuses
WOULD-DELETE /aws/lambda/hookipa-erp-production-getLocationTypes
WOULD-DELETE /aws/lambda/hookipa-erp-production-getInvoicePDF
WOULD-DELETE /aws/lambda/hookipa-erp-production-precacheLists
WOULD-DELETE /aws/lambda/hookipa-erp-production-eventQueueConsumer
WOULD-DELETE /aws/lambda/hookipa-erp-production-createLocation
WOULD-DELETE /aws/lambda/hookipa-erp-production-getConsolidatedInvoiceCSV
WOULD-DELETE /aws/lambda/hookipa-erp-production-getServiceItems
WOULD-DELETE /aws/lambda/hookipa-erp-production-reactivateLocation
WOULD-DELETE /aws/lambda/hookipa-erp-production-resetRequestTimeout
WOULD-DELETE /aws/lambda/hookipa-erp-production-retryRequest
WOULD-DELETE /aws/lambda/hookipa-erp-production-getExtendFileContent
WOULD-DELETE /aws/lambda/hookipa-erp-production-updateConsolidatedInvoice
WOULD-DELETE /aws/lambda/hookipa-erp-production-processEmployeeEvents
WOULD-DELETE /aws/lambda/hookipa-erp-production-getPosPreferences
WOULD-DELETE /aws/lambda/hookipa-erp-production-updateCustomer
WOULD-DELETE /aws/lambda/hookipa-erp-production-getInvoiceAttachments
WOULD-DELETE /aws/lambda/hookipa-erp-production-updateCustomerCase
WOULD-DELETE /aws/lambda/hookipa-erp-production-updateInvoice
WOULD-DELETE /aws/lambda/hookipa-erp-production-processSiteWageRatesEvents
WOULD-DELETE /aws/lambda/hookipa-erp-production-updateLocation
WOULD-DELETE /aws/lambda/hookipa-erp-production-updateCreditMemo
WOULD-DELETE /aws/lambda/hookipa-erp-production-updateQuoteToCustomerCase
WOULD-DELETE /aws/lambda/hookipa-erp-production-updateServiceOrder
WOULD-DELETE /aws/lambda/hookipa-erp-production-updateServiceChangeRequest
WOULD-DELETE /aws/lambda/hookipa-erp-production-processSalesforceCustomerEvents
WOULD-DELETE /aws/lambda/hookipa-erp-production-getServiceOrderStatuses
WOULD-DELETE /aws/lambda/hookipa-erp-production-updateServicePerformance
WOULD-DELETE /aws/lambda/hookipa-erp-production-updateTradesSalesOrder
WOULD-DELETE /aws/lambda/hookipa-erp-production-updateVendor
WOULD-DELETE /aws/lambda/hookipa-erp-production-uploadServicePerformancePunchCounts
WOULD-DELETE /aws/lambda/hookipa-erp-staging-UpdateSalesOrderLine
WOULD-DELETE /aws/lambda/hookipa-erp-staging-UpdateViso
WOULD-DELETE /aws/lambda/hookipa-erp-staging-AddVisoApproval
WOULD-DELETE /aws/lambda/hookipa-erp-production-updateVendorBill
WOULD-DELETE /aws/lambda/hookipa-erp-staging-addMessageToInvoice
WOULD-DELETE /aws/lambda/hookipa-erp-staging-addMessageToCustomerCase
WOULD-DELETE /aws/lambda/hookipa-erp-staging-addMessageToConsolidatedInvoice
WOULD-DELETE /aws/lambda/hookipa-erp-staging-addNoteToServiceOrder
WOULD-DELETE /aws/lambda/hookipa-erp-staging-attachFileToLocation
WOULD-DELETE /aws/lambda/hookipa-erp-staging-attachFileToSalesOrder
WOULD-DELETE /aws/lambda/hookipa-erp-production-warmup-plugin-default
WOULD-DELETE /aws/lambda/hookipa-erp-staging-createJournalEntry
WOULD-DELETE /aws/lambda/hookipa-erp-staging-assignKbsCustomerIds
WOULD-DELETE /aws/lambda/hookipa-erp-staging-addNoteToCustomerCase
WOULD-DELETE /aws/lambda/hookipa-erp-staging-createServiceOrder
WOULD-DELETE /aws/lambda/hookipa-erp-staging-cloneInvoice
WOULD-DELETE /aws/lambda/hookipa-erp-staging-createConsolidatedInvoice
WOULD-DELETE /aws/lambda/hookipa-erp-staging-apiRouter
WOULD-DELETE /aws/lambda/hookipa-erp-staging-failRequest
WOULD-DELETE /aws/lambda/hookipa-erp-staging-getInvoiceAttachments
WOULD-DELETE /aws/lambda/hookipa-erp-staging-updateCustomer
WOULD-DELETE /aws/lambda/hookipa-erp-staging-updateCreditMemo
WOULD-DELETE /aws/lambda/hookipa-erp-staging-getRequestStatuses
WOULD-DELETE /aws/lambda/hookipa-erp-staging-updateServiceOrder
WOULD-DELETE /aws/lambda/hookipa-jechecklist-dev-getJeChecklistData
WOULD-DELETE /aws/lambda/jericho-prod-get
WOULD-DELETE /aws/lambda/kelsus-replicate-config23-menu
WOULD-DELETE /aws/lambda/kelsus-users-in-databases
WOULD-DELETE /aws/lambda/kronos-consumers-production-processEmployeeEvents
WOULD-DELETE /aws/lambda/kelsus-asg-alarms-handler
WOULD-DELETE /aws/lambda/kelsus-cdn-cache-invalidator
WOULD-DELETE /aws/lambda/kronos-consumers-production-processLaborPremiumEvents
WOULD-DELETE /aws/lambda/kronos-consumers-production-processLocationDeactivation
WOULD-DELETE /aws/lambda/kronos-consumers-production-processLocationEvents
WOULD-DELETE /aws/lambda/kelsus-cloudwatch-task-deregistration-metric
WOULD-DELETE /aws/lambda/kelsus-spot-logs-puller
WOULD-DELETE /aws/lambda/kronos-consumers-production-cleanupKronosPunchImportTable
WOULD-DELETE /aws/lambda/kronos-consumers-staging-cleanupKronosPunchImportTable
WOULD-DELETE /aws/lambda/kronos-consumers-staging-processEmployeeEvents
WOULD-DELETE /aws/lambda/kelsus-replicate-appconfig
WOULD-DELETE /aws/lambda/kronos-consumers-staging-processLocationDeactivation
WOULD-DELETE /aws/lambda/kronos-consumers-staging-processLocationEvents
WOULD-DELETE /aws/lambda/labor-db-dev-applyDatabaseMigrations
WOULD-DELETE /aws/lambda/labor-db-dev-loadS3FileToTable
WOULD-DELETE /aws/lambda/kelsus-subsidiaries-updater
WOULD-DELETE /aws/lambda/labor-db-production-loadS3FileToTable
WOULD-DELETE /aws/lambda/labor-db-production-applyDatabaseMigrations
WOULD-DELETE /aws/lambda/labor-db-staging-loadS3FileToTable
KEEP         /aws/lambda/lido-api-dev-getLaborDetails
WOULD-DELETE /aws/lambda/labor-db-staging-applyDatabaseMigrations
KEEP         /aws/lambda/lido-api-production-getLaborDetails
KEEP         /aws/lambda/lido-api-production-getPayPeriods
WOULD-DELETE /aws/lambda/kelsus-sns-to-slack
KEEP         /aws/lambda/lido-api-staging-getPayPeriods
KEEP         /aws/lambda/lido-api-staging-getSiteDetails
KEEP         /aws/lambda/lido-consumer-dev-bootstrapSiteBudgetHourAggs
KEEP         /aws/lambda/lido-consumer-dev-processAttestationEvents
KEEP         /aws/lambda/lido-consumer-dev-processBudgetRecordEvents
KEEP         /aws/lambda/lido-consumer-dev-processEmployeeEvents
KEEP         /aws/lambda/lido-consumer-dev-processBudgetRecordsEvents
KEEP         /aws/lambda/lido-consumer-dev-processEmployeePunchesEvents
KEEP         /aws/lambda/lido-consumer-dev-processHSSLocationEvents
KEEP         /aws/lambda/lido-consumer-dev-processLocationHierarchyEvents
KEEP         /aws/lambda/lido-api-dev-getPayPeriods
KEEP         /aws/lambda/lido-consumer-dev-processLocationEvents
KEEP         /aws/lambda/lido-api-staging-getLaborDetails
WOULD-DELETE /aws/lambda/kronos-consumers-staging-processLaborPremiumEvents
KEEP         /aws/lambda/lido-consumer-production-bootstrapSiteBudgetHourAggs
KEEP         /aws/lambda/lido-consumer-production-processAttestationEvents
KEEP         /aws/lambda/lido-consumer-production-processBudgetRecordEvents
KEEP         /aws/lambda/lido-consumer-production-processEmployeeEvents
KEEP         /aws/lambda/lido-consumer-production-processLocationEvents
KEEP         /aws/lambda/lido-consumer-staging-bootstrapSiteBudgetHourAggs
KEEP         /aws/lambda/lido-consumer-staging-processAttestationEvents
KEEP         /aws/lambda/lido-consumer-staging-processAgreementEvents
KEEP         /aws/lambda/lido-consumer-staging-processHSSLocationEvents
KEEP         /aws/lambda/lido-consumer-dev-processSiteBudgetHourAggEvents
KEEP         /aws/lambda/lido-jobs-dev-publishLaborPremiums
KEEP         /aws/lambda/lido-jobs-dev-calculateMealBreakPremiums
KEEP         /aws/lambda/lido-consumer-staging-processSiteBudgetHourAggEvents
KEEP         /aws/lambda/lido-jobs-staging-allocatePeriodicBudgetsForDateRange
WOULD-DELETE /aws/lambda/makua-dev-AssembleServicesNotifications
WOULD-DELETE /aws/lambda/makua-dev-ProcessContactBatch
WOULD-DELETE /aws/lambda/makua-production-PullExpectedServices
WOULD-DELETE /aws/lambda/makua-production-MarkCompletion
WOULD-DELETE /aws/lambda/makua-production-customers-handler
WOULD-DELETE /aws/lambda/makua-production-dynamo_stream_handler
WOULD-DELETE /aws/lambda/makua-production-email_notification-enqueue_pending
WOULD-DELETE /aws/lambda/makua-production-MarkPunchMatchingCompletion
WOULD-DELETE /aws/lambda/makua-production-employees-handler
WOULD-DELETE /aws/lambda/makua-production-MarkWorkflowCompletion
WOULD-DELETE /aws/lambda/makua-production-MatchPunches
WOULD-DELETE /aws/lambda/makua-production-employee-punches-handler
WOULD-DELETE /aws/lambda/makua-dev-subscription-items-handler
WOULD-DELETE /aws/lambda/makua-production-entity-contacts-handler
WOULD-DELETE /aws/lambda/makua-dev-vendor-punches-handler
WOULD-DELETE /aws/lambda/makua-production-locations-handler
WOULD-DELETE /aws/lambda/makua-production-punch-spr-matches-handler
WOULD-DELETE /aws/lambda/makua-production-sendgrid-webhook-handler
WOULD-DELETE /aws/lambda/makua-production-service-performances-handler
WOULD-DELETE /aws/lambda/makua-production-service-orders-handler
WOULD-DELETE /aws/lambda/makua-production-MarkMissedServices
WOULD-DELETE /aws/lambda/makua-production-FetchContactBatches
WOULD-DELETE /aws/lambda/makua-production-FetchCandidateServiceEvents
WOULD-DELETE /aws/lambda/makua-production-EvaluatePunchMatchingBatch
WOULD-DELETE /aws/lambda/makua-production-status-progression-runner
WOULD-DELETE /aws/lambda/makua-production-vendor-punches-handler
WOULD-DELETE /aws/lambda/makua-production-vendors-handler
WOULD-DELETE /aws/lambda/makua-production-NotifyNoMissedServices
WOULD-DELETE /aws/lambda/makua-scheduled-kafka-pub-LogRetentionaae0aa3c5b4d-u4SfUaRwppsh
WOULD-DELETE /aws/lambda/makua-production-ProcessContactBatch
WOULD-DELETE /aws/lambda/makua-scheduled-kafka-publisher-production
WOULD-DELETE /aws/lambda/makua-staging-AssembleServicesAlertsNotifications
WOULD-DELETE /aws/lambda/makua-staging-AssembleServicesNotifications
WOULD-DELETE /aws/lambda/makua-staging-CreateNotificationsBatch
WOULD-DELETE /aws/lambda/makua-scheduled-kafka-pub-LogRetentionaae0aa3c5b4d-Gza0Sl2gKpBI
WOULD-DELETE /aws/lambda/makua-staging-MarkMissedServices
WOULD-DELETE /aws/lambda/makua-scheduled-kafka-publisher-dev
WOULD-DELETE /aws/lambda/makua-staging-MarkWorkflowCompletion
WOULD-DELETE /aws/lambda/makua-scheduled-kafka-pub-LogRetentionaae0aa3c5b4d-B6KnPSY7jFHG
WOULD-DELETE /aws/lambda/makua-staging-employees-handler
WOULD-DELETE /aws/lambda/makua-staging-PullExpectedServices
WOULD-DELETE /aws/lambda/makua-staging-email_notification-enqueue_pending
WOULD-DELETE /aws/lambda/makua-staging-customers-handler
WOULD-DELETE /aws/lambda/makua-staging-punch-spr-matches-handler
WOULD-DELETE /aws/lambda/makua-staging-service-performances-handler
WOULD-DELETE /aws/lambda/makua-staging-vendors-handler
WOULD-DELETE /aws/lambda/malaga-dev-migrateDatabase
WOULD-DELETE /aws/lambda/malaga-dev-produceEmployeeVaccinations
WOULD-DELETE /aws/lambda/malaga-staging-runBackgroundCheckReport
WOULD-DELETE /aws/lambda/malaga-staging-produceEmployeeVaccinationStatuses
WOULD-DELETE /aws/lambda/manuel-devui-sst-Default-siteServerFunction6DFA6F1-2MKR73XrCOEX
WOULD-DELETE /aws/lambda/manuel-devui-sst-Default-ApiLambdaGETtimeE46B73FE-NcSbRg57Q57Q
WOULD-DELETE /aws/lambda/manuel-devui-sst-Default-LogRetentionaae0aa3c5b4d4-3Z3nRdu6K0am
WOULD-DELETE /aws/lambda/manuel-devui-sst-Default-siteServerFunction6DFA6F1-aj5gVx6MfheG
WOULD-DELETE /aws/lambda/manuel-devui-sst-Default-siteServerFunction6DFA6F1-ovHYaIn3oM8g
WOULD-DELETE /aws/lambda/manuel-devui-sst-Default-LogRetentionaae0aa3c5b4d4-shV6nEHw9ZRF
WOULD-DELETE /aws/lambda/manuel-devui-sst-Default-ApiLambdaGETB1714EF3-6uYbykFkvDj4
WOULD-DELETE /aws/lambda/manuel-sst-devui-Default-CustomResourceHandlerE8FB-1nqTeLoyNNOV
WOULD-DELETE /aws/lambda/manuel-sst-devui-Default-CustomResourceHandlerE8FB-zTm9xKVK1hOI
WOULD-DELETE /aws/lambda/manuel-sst-devui-Default-LogRetentionaae0aa3c5b4d4-Wt2TlP6Yg5Bq
WOULD-DELETE /aws/lambda/manuel-sst-devui-Default-apiLambdaGET2D5CB7A7-qEkEm1ZXbXQo
WOULD-DELETE /aws/lambda/malaga-staging-migrateDatabase
WOULD-DELETE /aws/lambda/manuel-sst-devui-Default-apiLambdaGETcustomers19A9-fTKAHDeeiwpm
WOULD-DELETE /aws/lambda/manuel-sst-devui-Default-apiLambdaGETcustomersuuid-T4qNCwGKEbSf
WOULD-DELETE /aws/lambda/manuel-devui-sst-Default-CustomResourceHandlerE8FB-w1Zj3lxpXole
WOULD-DELETE /aws/lambda/manuel-sst-devui-Default-apiLambdaGETstagecustomer-78PYXcbgmneH
WOULD-DELETE /aws/lambda/manuel-sst-devui-Default-apiLambdaGETstagecustomer-STRiDgNp8I8A
WOULD-DELETE /aws/lambda/manuel-devui-sst-Default-ApiLambdaGETB1714EF3-GEUs9y5JxJRp
WOULD-DELETE /aws/lambda/manuel-sst-devui-Default-apiLambdaGETstagecustomer-XF0A3CgjJsLF
WOULD-DELETE /aws/lambda/manuel-devui-sst-Default-CustomResourceHandlerE8FB-Kk0QwWui8HdY
WOULD-DELETE /aws/lambda/manuel-sst-devui-Default-apiLambdaGETstagecustomer-Y8WNEyK1i1tD
WOULD-DELETE /aws/lambda/manuel-sst-devui-Default-apiLambdaGETstagecustomer-hI1XleWKSO8C
WOULD-DELETE /aws/lambda/manuel-devui-sst-Default-LogRetentionaae0aa3c5b4d4-5keAEfh7s3eG
WOULD-DELETE /aws/lambda/manuel-sst-devui-Default-apiLambdaGETstagelocation-8KgukgfJup9O
WOULD-DELETE /aws/lambda/manuel-sst-devui-Default-apiLambdaGETstageworkorde-vvyAEaDBcJD9
WOULD-DELETE /aws/lambda/manuel-sst-devui-Default-apiLambdaGETstageeventrul-hi2ZkfMpiAZ8
WOULD-DELETE /aws/lambda/manuel-sst-devui-Default-siteServerFunction6DFA6F1-ry5Uh1JVJ04f
WOULD-DELETE /aws/lambda/manuel-sst-devui-Default-apiLambdaGETenvcustomers4-VugQ3sLUJ3Im
WOULD-DELETE /aws/lambda/myrtle-production-lambdaAlarmHandler
WOULD-DELETE /aws/lambda/mm-live-tracker-collector
WOULD-DELETE /aws/lambda/myrtle-production-lambdaTriggerErrorHandler
WOULD-DELETE /aws/lambda/manuel-sst-devui-Default-siteServerFunction6DFA6F1-qDqiP4dMLf5n
WOULD-DELETE /aws/lambda/myrtle-staging-lambdaAlarmHandler
WOULD-DELETE /aws/lambda/manuel-devui-sst-Default-CustomResourceHandlerE8FB-5CuvHyr5yvkI
WOULD-DELETE /aws/lambda/nanomolina-sst-devui-Defa-CustomResourceHandlerE8F-4bcq26dxI51c
WOULD-DELETE /aws/lambda/manuel-sst-devui-Default-LogRetentionaae0aa3c5b4d4-4gndz9ywOaH2
WOULD-DELETE /aws/lambda/nanomolina-sst-devui-Defa-apiLambdaGETstagecustome-sQ7GS2zitGJ3
WOULD-DELETE /aws/lambda/nanomolina-sst-devui-Defa-apiLambdaGETstagecustome-ziXcEQt9mKJa
WOULD-DELETE /aws/lambda/nanomolina-sst-devui-Defa-apiLambdaGETstagecustome-CfXoDO1c6B2D
WOULD-DELETE /aws/lambda/nanomolina-sst-devui-Defa-apiLambdaGETstagecustome-v9KoQLJbJc5H
WOULD-DELETE /aws/lambda/nanomolina-sst-devui-Defa-apiLambdaGETstagelocatio-KJczRdpUl9cg
WOULD-DELETE /aws/lambda/nanomolina-sst-devui-Defa-siteServerFunction6DFA6F-ur9VbAJDtaX5
WOULD-DELETE /aws/lambda/netsuite-case-records-stg-netsuite_case_records
WOULD-DELETE /aws/lambda/nauset-netsuite-webhook
WOULD-DELETE /aws/lambda/nanomolina-sst-devui-Defa-LogRetentionaae0aa3c5b4d-8nsSUZi2JcZb
WOULD-DELETE /aws/lambda/nanomolina-sst-devui-Defa-apiLambdaGETstageworkord-O1YKmRsawpHD
WOULD-DELETE /aws/lambda/myrtle-staging-lambdaTriggerErrorHandler
WOULD-DELETE /aws/lambda/netsuite-vendor-onelogin-create
WOULD-DELETE /aws/lambda/no-punch-no-pay-match-report-Function6B188E59-lM6eGImUtKIJ
WOULD-DELETE /aws/lambda/node/adm-network-route
WOULD-DELETE /aws/lambda/nanomolina-sst-devui-Defa-apiLambdaGETstageeventru-QU6HcmXyFncd
WOULD-DELETE /aws/lambda/node/kelsus-spot-logs-puller
WOULD-DELETE /aws/lambda/netsuite-service-records-stg-netsuite_service_records
WOULD-DELETE /aws/lambda/node/kelsus-subsidiaries-updater
WOULD-DELETE /aws/lambda/peoplenet-punch-export-dev-exportPunchesForDateRange
WOULD-DELETE /aws/lambda/peoplenet-punch-export-dev-uploadPunchesViaFTP
WOULD-DELETE /aws/lambda/netsuite-to-operations-stg-netsuite_to_operations
WOULD-DELETE /aws/lambda/no-punch-no-pay-ui-backendServerFunction10FBACF6-mDYcU8UupxQ7
WOULD-DELETE /aws/lambda/peoplenet-punch-export-production-processHSSAssignmentsEvents
WOULD-DELETE /aws/lambda/peoplenet-punch-export-production-uploadPunchesViaFTP
WOULD-DELETE /aws/lambda/netsuite-locations-stg-netsuite_locations
WOULD-DELETE /aws/lambda/peoplenet-punch-export-production-exportPunchesForDateRange
WOULD-DELETE /aws/lambda/oneprocdash-workflowStarterLambda-F7AWS918Z7P4
WOULD-DELETE /aws/lambda/peoplenet-punch-export-dev-exportPeopleNetPunches
WOULD-DELETE /aws/lambda/peoplenet-punch-export-staging-exportPunchesForDateRange
WOULD-DELETE /aws/lambda/peoplenet-punch-export-staging-processPeopleNetPunchEvents
WOULD-DELETE /aws/lambda/pinamar-staging-processEmployeePunches
WOULD-DELETE /aws/lambda/openvpn-accessserver-GetASProps-PQJGNlvYcATk
WOULD-DELETE /aws/lambda/prod-sst-devui-Default-CustomS3AutoDeleteObjectsCu-AQtmMXbLtzLx
WOULD-DELETE /aws/lambda/prod-sst-devui-Default-apiLambdaGETstagelocationsu-WhOPaclN2lFd
WOULD-DELETE /aws/lambda/s3_workday_integration_files_delete_alerts
WOULD-DELETE /aws/lambda/schooner-dev-processCintasTransactionsEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processConcurPipelineTransFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processAmazonLocationsFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processConcurCashAdvancesEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processAmazonLocationHoursEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processBradyPlusTransactionsFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processEmailWithPipeline
WOULD-DELETE /aws/lambda/schooner-dev-processConcurEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processConcurFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processBradyPlusTransactionsEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processConcurCashAdvancesFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processBimGlBudgetOpExUploadFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processCintasTransactionsFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processAnaplanUploadFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processEmployeeFeaturesFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processAramarkTransactionsEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processConcurPipelineTransEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processFlexkitBudgetEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processFlexkitBudgetFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processFlexkitBufferEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processFlexkitBufferFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processGlBudgetForecastUploadFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processFlexkitShippedEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processAvionteHoursEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processGlBudgetMandAUploadFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processGlBudgetOpExUpdtUploadFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processEmployeeNysidWagesFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processHssLaborHoursEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processHeadcountFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processPetsmartHeadcountFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processSplySolConsInvEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processSplySolConsInvFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processLocationPayrollFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processHdSupplyTransactionsEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processNetworkDistributionEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processHeadcountEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processTargetAuditMasterFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processHssLaborHoursFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processTssInventoryCsvFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-processTssConsInvEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-dev-removeRdbFileUploadUserPipeline
WOULD-DELETE /aws/lambda/schooner-production-getRdbFileUploadPipelines
WOULD-DELETE /aws/lambda/schooner-production-processAmazonLocationHoursEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processAribaInvoicesUploadFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processAramarkTransactionsFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processConcurCashAdvancesEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processAmazonLocationsFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processConcurEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processConcurCashAdvancesFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processBradyPlusTransactionsFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processEmailWithPipeline
WOULD-DELETE /aws/lambda/schooner-production-processConcurPipelineTransFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processAvionteHoursFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processCintasTransactionsEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processAmazonPOAmountsEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processBradyPlusTransactionsEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processEmployeeFeaturesFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processAnaplanUploadFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processEmployeeNysidWagesFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processAvionteHoursEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processFlexkitBufferEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processFlexkitBufferFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processConcurPipelineTransEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processBimGlBudgetOpExUpdtUploadFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processFlexkitShippedEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processFlexkitShippedFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processBimGlBudgetOpExUploadFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processGlBudgetForecastUploadFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processGlBudgetOpExUpdtUploadFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processGlBudgetMandAUploadFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processGlBudgetOpExUploadFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processHdSupplyTransactionsEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processHeadcountFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processLocationFeaturesFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processFlexkitBudgetEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processNetworkDistributionEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processRdbFileUpload
WOULD-DELETE /aws/lambda/schooner-production-processPetsmartHeadcountEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processPetsmartHeadcountFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processNetworkDistributionFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processStrictShiftControlFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processTargetAuditMasterEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processSplySolConsInvFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processTrainingComplianceEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processTargetAuditMasterFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processStaplesTransactionsUploadFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processSplySolShipmentEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processFlexkitBudgetFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-removeRdbFileUploadUserPipeline
WOULD-DELETE /aws/lambda/schooner-production-processTssShipmentEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-aggAmazonHeadcount
WOULD-DELETE /aws/lambda/schooner-production-processHssLaborHoursFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-processAmazonPOAmountsFromS3Event
WOULD-DELETE /aws/lambda/schooner-production-processTssShipmentFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-processAmazonLocationsEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-processBimGlBudgetOpExUpdtUploadFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-processAvionteHoursEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-processConcurCashAdvancesFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-processHdSupplyTransactionsFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-processFlexkitBufferFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-processGlBudgetForecastUploadFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-processHeadcountFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-processFlexkitShippedFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-processConcurPipelineTransEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-processEmployeeNysidWagesFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-processHssLaborHoursFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-processHssLaborHoursEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-processLocationFeaturesFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-processHdSupplyTransactionsEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-processGlBudgetOpExUpdtUploadFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-processPetsmartHeadcountFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-processRdbFileUpload
WOULD-DELETE /aws/lambda/schooner-staging-processGlBudgetOpExUploadFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-processS3ObjectWithPipeline
WOULD-DELETE /aws/lambda/schooner-staging-processSplySolConsInvFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-processLocationPayrollFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-processPetsmartHeadcountEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-processGlBudgetMandAUploadFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-processSplySolShipmentEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-processTrainingComplianceFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-processTssConsInvFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-processSplySolShipmentFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-processTssInventoryCsvFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-processTssShipmentEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-processTssInventoryEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-processTssShipmentFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-removeRdbFileUploadUserPipeline
WOULD-DELETE /aws/lambda/schooner-test1-aggAmazonHeadcount
WOULD-DELETE /aws/lambda/schooner-staging-processNetworkDistributionEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-getRdbFileUploadPipelines
WOULD-DELETE /aws/lambda/schooner-test1-processAmazonLocationHoursFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processAmazonLocationsFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processAmazonPOAmountsEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processAramarkTransactionsFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processAribaInvoicesUploadFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processAnaplanUploadFromS3Event
WOULD-DELETE /aws/lambda/schooner-staging-processTssConsInvEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processCintasTransactionsEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processAvionteHoursEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processConcurPipelineTransEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processAmazonLocationHoursEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processConcurEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processAmazonPOAmountsFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processAmazonLocationsEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processBimGlBudgetOpExUploadFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processBimGlBudgetOpExUpdtUploadFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processConcurPipelineTransFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processBradyPlusTransactionsFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processCintasTransactionsFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-aggWarehouseInventoryWeekly
WOULD-DELETE /aws/lambda/schooner-test1-processBradyPlusTransactionsEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processBimGlBudgetMandAUploadFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processAramarkTransactionsEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processConcurCashAdvancesEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processEmployeeFeaturesFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processConcurCashAdvancesFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processFlexkitBudgetEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processFlexkitBufferEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processEmployeeNysidWagesFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processFlexkitBudgetFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processConcurFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processFlexkitBufferFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processGlBudgetForecastUploadFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processGlBudgetMandAUploadFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processFlexkitShippedFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processGlBudgetOpExUpdtUploadFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processEmailWithPipeline
WOULD-DELETE /aws/lambda/schooner-test1-processGlBudgetOpExUploadFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processHdSupplyTransactionsFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processHeadcountEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processLocationFeaturesFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processNetworkDistributionFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processPetsmartHeadcountEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processSplySolConsInvEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processSplySolConsInvFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processSplySolShipmentFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processHssLaborHoursFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processStaplesTransactionsUploadFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processHeadcountFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processHdSupplyTransactionsEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processRdbFileUpload
WOULD-DELETE /aws/lambda/schooner-test1-processPetsmartHeadcountFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processTssConsInvFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processStrictShiftControlFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processTssInventoryEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processTargetAuditMasterEmailFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processTssShipmentFromS3Event
WOULD-DELETE /aws/lambda/schooner-test1-processTssShipmentEmailFromS3Event
WOULD-DELETE /aws/lambda/stitch-run-status-handler-sandbox
WOULD-DELETE /aws/lambda/superglue-dev-createStagingTablesForJob
WOULD-DELETE /aws/lambda/superglue-production-createDatabaseClusterSnapshot
WOULD-DELETE /aws/lambda/superglue-production-createStagingTablesForJob
WOULD-DELETE /aws/lambda/superglue-dev-runEndOfJobPostProcessing
WOULD-DELETE /aws/lambda/superglue-test1-runEndOfJobPostProcessing
WOULD-DELETE /aws/lambda/superglue-test1-runEndOfWorkflowPostProcessing
WOULD-DELETE /aws/lambda/superglue-test1-dropStagingTablesForWorkflow
WOULD-DELETE /aws/lambda/superglue-staging-runEndOfJobPostProcessing
WOULD-DELETE /aws/lambda/superglue-test1-startGlueJob
WOULD-DELETE /aws/lambda/superglue-test1-stgProdRowCountPostDeployCheck
WOULD-DELETE /aws/lambda/svcchnl-webhook-dev-notify
WOULD-DELETE /aws/lambda/superglue-staging-executePostCrawlerActions
WOULD-DELETE /aws/lambda/superglue-test1-createDatabaseClusterSnapshot
WOULD-DELETE /aws/lambda/superglue-test1-createStagingTablesForJob
WOULD-DELETE /aws/lambda/temp_event_rule
WOULD-DELETE /aws/lambda/superglue-test1-executePostCrawlerActions
WOULD-DELETE /aws/lambda/superglue-test1-createStagingTablesForWorkflow
WOULD-DELETE /aws/lambda/superglue-staging-runEndOfWorkflowPostProcessing
WOULD-DELETE /aws/lambda/superglue-staging-createStagingTablesForWorkflow
WOULD-DELETE /aws/lambda/superglue-test1-executePostJobActions
WOULD-DELETE /aws/lambda/test-durable
WOULD-DELETE /aws/lambda/test-lambda
WOULD-DELETE /aws/lambda/superglue-test1-applyDatabaseMigrations
WOULD-DELETE /aws/lambda/test
WOULD-DELETE /aws/lambda/test1-triggerHudiWriterIntegration
WOULD-DELETE /aws/lambda/test1-stitch-webhook
WOULD-DELETE /aws/lambda/us-east-1.EACloudFrontRedirect
WOULD-DELETE /aws/lambda/us-east-1.ataylor-cloudfront-authenticate4
WOULD-DELETE /aws/lambda/superglue-test1-createFactLocationScheduleTableSnapshot
WOULD-DELETE /aws/lambda/us-east-1.ataylor-cloudfront-authenticate5
WOULD-DELETE /aws/lambda/test1-triggerHudiWriter
WOULD-DELETE /aws/lambda/test-yaml
WOULD-DELETE /aws/lambda/usW2DevNotificationsServe-CustomDeleteExistingReco-PBttxwHsdkQd
WOULD-DELETE /aws/lambda/usW2DevKelsusTestingClien-CustomDeleteExistingReco-BjhOHBTDcCTW
WOULD-DELETE /aws/lambda/usW2DevRolodexServerStack-CustomCDKECRDeploymentbd-Y9obNNBOWNaU
WOULD-DELETE /aws/lambda/us-east-1.rdb-file-upload-authenticator-test1
WOULD-DELETE /aws/lambda/usW2DevStaffModuleStack-CustomDeleteExistingRecord-zg0mWi0vaAWI
WOULD-DELETE /aws/lambda/us-east-1.rdb-file-upload-authenticator-development
WOULD-DELETE /aws/lambda/usW2DevWageRateMgmtStack-CustomDeleteExistingRecor-tbytN1JCJG3t
WOULD-DELETE /aws/lambda/usW2ProdServiceCalendarCl-CustomDeleteExistingReco-Y3Eihsg8NbBZ
WOULD-DELETE /aws/lambda/usW2ProdStaffModuleStack-CustomDeleteExistingRecor-gWDPZaMM4kkl
WOULD-DELETE /aws/lambda/usW2ProdVendorsClientStac-CustomDeleteExistingReco-S9IKGc7N0DQe
WOULD-DELETE /aws/lambda/usW2ProdCasesClientStack-CustomDeleteExistingRecor-ejGaXPTnmQuW
WOULD-DELETE /aws/lambda/usW2ProdNotificationsServ-CustomDeleteExistingReco-N98KWbKlYYZz
WOULD-DELETE /aws/lambda/usW2ProdKbsforceLandingPa-CustomDeleteExistingReco-BmA6i1jc1XEB
WOULD-DELETE /aws/lambda/usW2StgRolodexServerStack-CustomCDKECRDeploymentbd-WoUjosiEvsqn
WOULD-DELETE /aws/lambda/usW2ProdAttestationServer-CustomDeleteExistingReco-JKqLfxakOzHX
WOULD-DELETE /aws/lambda/usW2ProdKbsforceLandingPa-CustomDeleteExistingReco-bOukgzzbCnYu
WOULD-DELETE /aws/lambda/usW2StgServiceCalendarCli-CustomDeleteExistingReco-uYnNuFTgLM4g
WOULD-DELETE /aws/lambda/usW2ProdAiCoreServerStack-CustomDeleteExistingReco-D8d5gh6gl1HM
WOULD-DELETE /aws/lambda/usW2StgEntraAccessVisibil-CustomDeleteExistingReco-VaBVEnyPmihm
WOULD-DELETE /aws/lambda/usW2StgVendorsClientStack-CustomDeleteExistingReco-u1GikY4VgH1z
WOULD-DELETE /aws/lambda/usW2StgSuppliesAndEquipme-CustomDeleteExistingReco-nqGwQ6SWh7OU
WOULD-DELETE /aws/lambda/usW2StgUserinfoProxyStack-CustomDeleteExistingReco-KTEWpuFKIeNc
WOULD-DELETE /aws/lambda/usW2StgWageRateMgmtStack-CustomDeleteExistingRecor-4qdGwHDZoc1U
WOULD-DELETE /aws/lambda/wasaga-dev-checkOngoingWeatherAndPunches
WOULD-DELETE /aws/lambda/usW2StgStaffModuleStack-CustomDeleteExistingRecord-bBBdcYGCIG5I
WOULD-DELETE /aws/lambda/usW2StgAiCoreServerStack-CustomDeleteExistingRecor-jCvVYm3NFkW3
WOULD-DELETE /aws/lambda/wasaga-dev-getSiteStatusDescriptions
WOULD-DELETE /aws/lambda/wasaga-dev-processCasesEvents
WOULD-DELETE /aws/lambda/wasaga-dev-getAllSites
WOULD-DELETE /aws/lambda/wasaga-dev-processVendorEvents
WOULD-DELETE /aws/lambda/wasaga-dev-getSiteDetails
WOULD-DELETE /aws/lambda/wasaga-production-getSiteStatusDescriptions
WOULD-DELETE /aws/lambda/wasaga-production-getSiteServiceStatuses
WOULD-DELETE /aws/lambda/wasaga-production-getAllSites
WOULD-DELETE /aws/lambda/wasaga-production-checkOngoingWeatherAndPunches
WOULD-DELETE /aws/lambda/wasaga-dev-processPunchesEvents
WOULD-DELETE /aws/lambda/wasaga-production-processLocationsEvents
WOULD-DELETE /aws/lambda/wasaga-production-processPunchesEvents
WOULD-DELETE /aws/lambda/wasaga-production-processVendorEvents
WOULD-DELETE /aws/lambda/wasaga-dev-processLocationsEvents
WOULD-DELETE /aws/lambda/wasaga-production-warmup-plugin-default
WOULD-DELETE /aws/lambda/wasaga-staging-getSiteServiceStatuses
WOULD-DELETE /aws/lambda/wasaga-staging-processLocationsEvents
WOULD-DELETE /aws/lambda/wasaga-staging-getSiteDetails
WOULD-DELETE /aws/lambda/wasaga-staging-warmup-plugin-default
WOULD-DELETE /aws/lambda/web-automator-dev-poll_request
WOULD-DELETE /aws/lambda/wasaga-staging-getSiteStatusDescriptions
WOULD-DELETE /aws/lambda/wasaga-staging-getAllSites
WOULD-DELETE /aws/lambda/web-automator-production-poll_request
KEEP         /aws/lambda/windansea-production-gsnWebHook
WOULD-DELETE /aws/lambda/web-automator-production-webAutomatorReport
WOULD-DELETE /aws/lambda/web-automator-dev-request_executor
WOULD-DELETE /aws/lambda/web-automator-dev-webAutomatorReport
WOULD-DELETE /aws/lambda/wasaga-staging-processVendorEvents


>>> Done. (Each dot on stderr = one log group without our filter.)
```
</details>

